### PR TITLE
ci(release): build Linux aarch64 wheel + sdist for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,60 @@ jobs:
           path: dist/*.whl
           retention-days: 7
 
+  # Build the Linux aarch64 wheel separately: it must be cross-compiled inside a
+  # manylinux container (via maturin-action) rather than with a bare
+  # `maturin build`, which can't produce a manylinux-compliant arm64 wheel on an
+  # x86_64 runner. Without this, Apple-Silicon dev containers (linux/arm64) have
+  # no installable wheel and `uv sync` fails to resolve office-oxide.
+  build-python-wheel-linux-aarch64:
+    name: Build Python wheel (aarch64-unknown-linux-gnu)
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          target: aarch64
+          manylinux: manylinux_2_28
+          args: --release --features python --out dist
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-linux-aarch64
+          path: dist/*.whl
+          retention-days: 7
+
+  # Build a source distribution as a universal fallback: any Rust-capable
+  # platform can build office-oxide from source when no prebuilt wheel matches.
+  # Named wheels-* so the publish-pypi download glob picks it up.
+  build-python-sdist:
+    name: Build Python sdist
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+          retention-days: 7
+
   # Package Node-native npm package with prebuilt native libs
   package-node-native:
     name: Package node-native npm (office-oxide)
@@ -682,6 +736,8 @@ jobs:
       - validate
       - build-binaries
       - build-python-wheels
+      - build-python-wheel-linux-aarch64
+      - build-python-sdist
       - build-wasm
       - build-native-libs
       - verify-python-wheel
@@ -803,7 +859,7 @@ jobs:
   # Publish to PyPI
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate, build-python-wheels, create-release]
+    needs: [validate, build-python-wheels, build-python-wheel-linux-aarch64, build-python-sdist, create-release]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Installing `office-oxide` on **Linux/arm64** fails because no compatible artifact is published:

```
error: Distribution `office-oxide==0.1.2` can't be installed because it doesn't
have a source distribution or wheel for the current platform

hint: You're on Linux (`manylinux_2_36_aarch64`), but `office-oxide` (v0.1.2) only
has wheels for: `manylinux_2_34_x86_64`, `macosx_10_12_x86_64`, `macosx_11_0_arm64`,
`win_amd64`
```

This bites anyone building a `linux/arm64` image — which is the **Docker Desktop default on Apple-Silicon (M-series) Macs**. Because there's also no sdist, `uv`/`pip` have no source fallback to build from, so resolution fails hard rather than degrading gracefully.

## Root cause

The tag-driven release pipeline (`.github/workflows/release.yml`) is what publishes to PyPI, and its `build-python-wheels` matrix only covers four targets:

| Target | Wheel |
|---|---|
| `x86_64-unknown-linux-gnu` | `manylinux_*_x86_64` |
| `x86_64-apple-darwin` | `macosx_*_x86_64` |
| `aarch64-apple-darwin` | `macosx_*_arm64` |
| `x86_64-pc-windows-msvc` | `win_amd64` |

There is **no `aarch64-unknown-linux-gnu` wheel and no sdist** — exactly the gap in the error above. (For comparison, the release pipeline already cross-builds aarch64-linux for the CLI binaries and the Go/C#/Node native libs; only the Python wheels were missing it.)

## Fix

Add two jobs to `release.yml`, mirroring the recipe already proven in this repo's `python.yml`:

- **`build-python-wheel-linux-aarch64`** — cross-compiles a `manylinux_2_28` aarch64 wheel inside a container via `PyO3/maturin-action`. This is a dedicated job rather than another row in the existing matrix because a bare `maturin build --target aarch64-...` on an x86_64 runner can't produce a manylinux-compliant arm64 wheel.
- **`build-python-sdist`** — a source distribution as a universal fallback, so any Rust-capable platform can build from source when no prebuilt wheel matches.

Both artifacts are named `wheels-*`, so the existing `publish-pypi` download glob picks them up with no further change, and both are added to the `needs:` of `create-release` and `publish-pypi` so a release is gated on them.

## Notes

- Reuses the same pinned action SHAs already vendored in `python.yml`, so it introduces no new dependencies.
- This repo has two PyPI-publishing workflows (`release.yml` on tag push, `python.yml` on `release: published`). `python.yml` already builds aarch64 + musllinux + sdist, but the published 0.1.2 set matches `release.yml`'s output — so `release.yml` is the pipeline that actually shipped the incomplete set. This PR deliberately fixes only that pipeline to keep the diff minimal; deduplicating the two workflows is left as separate follow-up.
- Applies to the **next** tagged release; it can't retroactively add a 0.1.2 arm64 wheel.