### PR TITLE
chore(deps): bump quickxml 0.40.0 -> 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7315c86b26aaef0321fba33c9dcc160da659c6a9d278f0f6a5656d6561c03b"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
 # Core parsing
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 zip = { version = "8.1", default-features = false, features = ["deflate"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Description 

Fix Cargo Deny vulnerability for QuickXML:

   ├ Announcement: https://github.com/tafia/quick-xml/issues/970
   ├ Solution: Upgrade to >=0.41.0 (try `cargo update -p quick-xml`)
   ├ quick-xml v0.40.0
     └── office_oxide v0.1.2

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / tooling / CI only

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Tests added or updated for the changed behaviour
- [x] `cargo test` passes locally
- [ ] Documentation updated (public API changes have rustdoc, README updated if needed)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [x] All commits include a `Signed-off-by` trailer (`git commit -s`)

## Testing

<!-- Describe how you tested this change. Include relevant commands or output snippets. -->

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, known limitations, or follow-up work. -->
