### PR TITLE
fix(xml): make unescape_attr_value compile with quick-xml encoding feature (unblocks quick-xml >=0.41)

### DIFF
--- a/src/core/xml.rs
+++ b/src/core/xml.rs
@@ -251,16 +251,22 @@ pub fn unescape_text(e: &quick_xml::events::BytesText<'_>) -> Result<String> {
 
 /// Decode and unescape an `Attribute` value into an owned string.
 ///
-/// quick-xml 0.40 deprecated `Attribute::unescape_value()` in favor of
-/// `normalized_value()`, but the suggested replacement doesn't unescape
-/// XML entities (`&amp;`, `&lt;`, …) — only whitespace-normalizes. OOXML
-/// attribute values frequently contain hyperlinks and other content that
-/// need real entity unescaping, so we keep the old behaviour for now and
-/// centralise the deprecation suppression in one place.
-#[allow(deprecated)]
+/// quick-xml 0.40 deprecated `Attribute::unescape_value()`, and under the
+/// `encoding` feature the method is `cfg`-compiled out entirely (only
+/// `decode_and_unescape_value(decoder)` remains). Feature unification can
+/// turn `encoding` on transitively (e.g. via `calamine`), so relying on
+/// `unescape_value()` makes the build fragile — it fails to compile the
+/// moment any crate in the tree enables quick-xml's `encoding` feature.
+///
+/// OOXML documents are always UTF-8, so we decode the raw attribute bytes
+/// as UTF-8 and unescape XML entities (`&amp;`, `&lt;`, …) explicitly. This
+/// mirrors `unescape_text` above and is behaviourally identical to the old
+/// `unescape_value()` for UTF-8 input, while being independent of the
+/// `encoding` feature flag.
 pub fn unescape_attr_value(attr: &quick_xml::events::attributes::Attribute<'_>) -> Result<String> {
-    let cow = attr.unescape_value()?;
-    Ok(cow.into_owned())
+    let decoded = std::str::from_utf8(&attr.value)?;
+    let unescaped = quick_xml::escape::unescape(decoded).map_err(quick_xml::Error::from)?;
+    Ok(unescaped.into_owned())
 }
 
 /// Create a plain Reader (no namespace resolution) configured for OOXML parsing.


### PR DESCRIPTION
## Summary

`unescape_attr_value` calls `Attribute::unescape_value()`, which quick-xml
gates behind `#[cfg(not(feature = "encoding"))]` — when the `encoding` feature
is enabled, that method is compiled out entirely and only
`decode_and_unescape_value(decoder)` remains.

Cargo feature unification means any crate elsewhere in the dependency tree that
enables quick-xml's `encoding` feature (for example **calamine ≥ 0.36**, which
pulls `quick-xml` with `features = ["encoding"]`) turns `encoding` on for
`office_oxide` too, and the build then fails:

```
error[E0599]: no method named `unescape_value` found for reference `&Attribute<'_>`
   --> src/core/xml.rs:262:20
help: there is a method `decode_and_unescape_value` with a similar name, but with different arguments
```

This currently forces downstream crates (e.g. **kreuzberg**) to pin `calamine`
to `0.35`, which keeps a **vulnerable quick-xml < 0.41** in the tree
(**RUSTSEC-2026-0194 / RUSTSEC-2026-0195**, XML DoS).

## Fix

Replace the `encoding`-gated `unescape_value()` call with an explicit UTF-8
decode + entity unescape. OOXML documents are always UTF-8, so decoding the raw
attribute bytes as UTF-8 and running `quick_xml::escape::unescape` is
behaviourally identical to the old call for all valid OOXML input, and it is
independent of the `encoding` feature flag. This mirrors the existing
`unescape_text` helper directly above it.

## Testing

- `cargo test` passes with the current (default, `encoding` **off**) feature set: 16/16.
- `cargo test` also passes with `quick-xml`'s `encoding` feature **on** (the
  previously-failing configuration): 16/16.

Unblocks downstream consumers from moving to `quick-xml >= 0.41` and clearing
RUSTSEC-2026-0194 / RUSTSEC-2026-0195.
