### PR TITLE
fix(xml): decode attribute values without encoding-gated unescape_value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-if"
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -217,9 +217,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -255,15 +255,15 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "strsim"
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.1.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 [dependencies]
 # Core parsing
 quick-xml = { version = "0.41", features = ["serialize"] }
-zip = { version = "8.1", default-features = false, features = ["deflate"] }
+zip = { version = "8.6", default-features = false, features = ["deflate"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/core/xml.rs
+++ b/src/core/xml.rs
@@ -251,16 +251,17 @@ pub fn unescape_text(e: &quick_xml::events::BytesText<'_>) -> Result<String> {
 
 /// Decode and unescape an `Attribute` value into an owned string.
 ///
-/// quick-xml 0.40 deprecated `Attribute::unescape_value()` in favor of
-/// `normalized_value()`, but the suggested replacement doesn't unescape
-/// XML entities (`&amp;`, `&lt;`, …) — only whitespace-normalizes. OOXML
-/// attribute values frequently contain hyperlinks and other content that
-/// need real entity unescaping, so we keep the old behaviour for now and
-/// centralise the deprecation suppression in one place.
-#[allow(deprecated)]
+/// `Attribute::unescape_value()` is compiled out when quick-xml's `encoding`
+/// feature is enabled (it is `cfg(not(feature = "encoding"))`), which happens
+/// through cross-crate feature unification whenever another dependency pulls
+/// quick-xml with `encoding` (e.g. `calamine`). Decoding UTF-8 explicitly and
+/// expanding entities via `escape::unescape` keeps the exact behaviour — OOXML
+/// attribute values are always UTF-8 — while remaining feature-independent.
+/// Mirrors [`unescape_text`].
 pub fn unescape_attr_value(attr: &quick_xml::events::attributes::Attribute<'_>) -> Result<String> {
-    let cow = attr.unescape_value()?;
-    Ok(cow.into_owned())
+    let decoded = std::str::from_utf8(attr.value.as_ref())?;
+    let unescaped = quick_xml::escape::unescape(decoded).map_err(quick_xml::Error::from)?;
+    Ok(unescaped.into_owned())
 }
 
 /// Create a plain Reader (no namespace resolution) configured for OOXML parsing.


### PR DESCRIPTION
`Attribute::unescape_value()` is `cfg(not(feature = "encoding"))`, so it is compiled out whenever another crate in the dependency graph enables quick-xml's `encoding` feature through Cargo feature unification (`calamine`, for example). Any downstream that unifies office_oxide's quick-xml with such a crate then fails to build:

```
error[E0599]: no method named `unescape_value` found for reference `&Attribute<'_>`
  --> src/core/xml.rs:262
```

This decodes the attribute value as UTF-8 and expands entities via `escape::unescape` instead. OOXML attribute values are always UTF-8, so behaviour is unchanged, and the path no longer depends on the `encoding` feature. It mirrors the existing `unescape_text` helper.

Verified: full test suite passes, and the crate now compiles both with and without `quick-xml/encoding` enabled.

Note: This branch also carries  `zip 8.1 → 8.6` dependency bump.