### PR TITLE
release: v0.1.4 — quick-xml encoding-feature build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-07-12
+
+> Build-compatibility fix that unblocks downstream crates from moving to quick-xml ≥ 0.41 (and clearing RUSTSEC-2026-0194 / RUSTSEC-2026-0195) when office_oxide shares a dependency tree with a crate that enables quick-xml's `encoding` feature.
+
+### Fixed
+
+- **quick-xml `encoding`-feature build break** — `unescape_attr_value` called `Attribute::unescape_value()`, which quick-xml gates behind `#[cfg(not(feature = "encoding"))]`. Cargo feature unification turns `encoding` on transitively whenever another crate in the tree enables it (e.g. `calamine ≥ 0.36`), so office_oxide failed to compile with `error[E0599]: no method named unescape_value`. This forced downstreams (e.g. `kreuzberg`) to pin `calamine 0.35`, keeping a vulnerable quick-xml < 0.41 in the tree. The helper now decodes the raw attribute bytes as UTF-8 and expands entities via `escape::unescape`, which is feature-independent. Thanks @waxzce (#63) and @Goldziher (#64).
+
+### Changed
+
+- **`zip` 8.1 → 8.6** and assorted transitive dependency refreshes. Via #64 (@Goldziher).
+
 ## [0.1.3] - 2026-07-04
 
 > Security patch: clears every open RustSec advisory in the dependency tree — an untrusted-XML DoS (quick-xml), two pyo3 soundness/OOB fixes, and a memmap2 unsound-pointer fix — plus Linux aarch64 wheels on PyPI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.4] - 2026-07-12
+## [0.1.4] - 2026-07-13
 
 > Build-compatibility fix that unblocks downstream crates from moving to quick-xml ≥ 0.41 (and clearing RUSTSEC-2026-0194 / RUSTSEC-2026-0195) when office_oxide shares a dependency tree with a crate that enables quick-xml's `encoding` feature.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "atoi_simd",
  "encoding_rs",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "office_oxide",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "office_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ match_like_matches_macro = "allow"
 manual_find = "allow"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yfedoseev/office_oxide"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let ir = doc.to_ir(); // Format-agnostic intermediate representation
 
 ```toml
 [dependencies]
-office_oxide = "0.1.3"
+office_oxide = "0.1.4"
 ```
 
 ### JavaScript / WASM
@@ -309,7 +309,7 @@ Wheels available for Linux, macOS, and Windows. Python 3.8–3.14.
 
 ```toml
 [dependencies]
-office_oxide = "0.1.3"
+office_oxide = "0.1.4"
 ```
 
 ### JavaScript/WASM

--- a/crates/office_oxide_cli/Cargo.toml
+++ b/crates/office_oxide_cli/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.3", path = "../.." }
+office_oxide = { version = "0.1.4", path = "../.." }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/office_oxide_mcp/Cargo.toml
+++ b/crates/office_oxide_mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.3", path = "../.." }
+office_oxide = { version = "0.1.4", path = "../.." }
 serde_json = "1"
 
 [package.metadata.binstall]

--- a/csharp/OfficeOxide/OfficeOxide.csproj
+++ b/csharp/OfficeOxide/OfficeOxide.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PackageId>OfficeOxide</PackageId>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
     <Title>OfficeOxide</Title>
     <Authors>Yury Fedoseev</Authors>
     <Product>office_oxide</Product>

--- a/docs/getting-started-c.md
+++ b/docs/getting-started-c.md
@@ -67,7 +67,7 @@ LD_LIBRARY_PATH=/usr/local/lib ./quickstart
 ### Library info
 
 ```c
-const char *version = office_oxide_version();           // "0.1.3" — don't free
+const char *version = office_oxide_version();           // "0.1.4" — don't free
 const char *fmt     = office_oxide_detect_format("f"); // "docx"/... or NULL
 ```
 

--- a/docs/getting-started-csharp.md
+++ b/docs/getting-started-csharp.md
@@ -65,7 +65,7 @@ string md   = OfficeOxide.ToMarkdown("file.pptx");
 string html = OfficeOxide.ToHtml("file.xlsx");
 
 string? fmt = Document.DetectFormat("mystery.bin"); // null if unsupported
-Console.WriteLine(Document.Version);                // "0.1.3"
+Console.WriteLine(Document.Version);                // "0.1.4"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-javascript.md
+++ b/docs/getting-started-javascript.md
@@ -92,7 +92,7 @@ extractText('file.docx');      // string
 toMarkdown('file.pptx');       // string
 toHtml('file.xlsx');           // string
 detectFormat('mystery.bin');   // "docx" | ... | null
-version();                     // "0.1.3"
+version();                     // "0.1.4"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-python.md
+++ b/docs/getting-started-python.md
@@ -64,7 +64,7 @@ import office_oxide
 office_oxide.extract_text("file.docx")   # → str
 office_oxide.to_markdown("file.pptx")    # → str
 office_oxide.to_html("file.xlsx")        # → str
-office_oxide.version()                   # → "0.1.3"
+office_oxide.version()                   # → "0.1.4"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-office_oxide = "0.1.3"
+office_oxide = "0.1.4"
 ```
 
 ### Feature Flags
@@ -16,13 +16,13 @@ office_oxide = "0.1.3"
 ```toml
 [dependencies]
 # Default build — full read/write/edit support for all six formats.
-office_oxide = "0.1.3"
+office_oxide = "0.1.4"
 
 # Memory-mapped opens for large OOXML files.
-office_oxide = { version = "0.1.3", features = ["mmap"] }
+office_oxide = { version = "0.1.4", features = ["mmap"] }
 
 # Parallel parsing helpers.
-office_oxide = { version = "0.1.3", features = ["parallel"] }
+office_oxide = { version = "0.1.4", features = ["parallel"] }
 ```
 
 ## Quickstart

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Bumped in lockstep with the Rust crate.
-const defaultVersion = "0.1.3"
+const defaultVersion = "0.1.4"
 
 const releaseBase = "https://github.com/yfedoseev/office_oxide/releases/download"
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) for Node.js — native bindings backed by the Rust office_oxide library.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "office-oxide"
-version = "0.1.3"
+version = "0.1.4"
 description = "The fastest Office document processing library for Python — DOCX, XLSX, PPTX, DOC, XLS, PPT"
 requires-python = ">=3.8"
 license = { text = "MIT OR Apache-2.0" }

--- a/src/core/xml.rs
+++ b/src/core/xml.rs
@@ -260,9 +260,14 @@ pub fn unescape_text(e: &quick_xml::events::BytesText<'_>) -> Result<String> {
 ///
 /// OOXML documents are always UTF-8, so we decode the raw attribute bytes
 /// as UTF-8 and unescape XML entities (`&amp;`, `&lt;`, …) explicitly. This
-/// mirrors `unescape_text` above and is behaviourally identical to the old
-/// `unescape_value()` for UTF-8 input, while being independent of the
-/// `encoding` feature flag.
+/// mirrors `unescape_text` above and is independent of the `encoding` feature.
+///
+/// One deliberate difference from `unescape_value()`: that method additionally
+/// applied XML attribute-value whitespace normalization (a *literal* tab/CR/LF
+/// inside a value collapses to a space), which `escape::unescape` does not do.
+/// This never affects real OOXML — attribute values do not contain literal
+/// control whitespace, and character references (`&#9;`, `&#10;`) are unescaped
+/// identically either way.
 pub fn unescape_attr_value(attr: &quick_xml::events::attributes::Attribute<'_>) -> Result<String> {
     let decoded = std::str::from_utf8(&attr.value)?;
     let unescaped = quick_xml::escape::unescape(decoded).map_err(quick_xml::Error::from)?;
@@ -384,4 +389,39 @@ pub fn ensure_utf8(data: &[u8]) -> Option<Vec<u8>> {
     }
 
     Some(utf8)
+}
+
+#[cfg(test)]
+mod attr_tests {
+    use super::unescape_attr_value;
+    use quick_xml::events::BytesStart;
+
+    /// Parse `<e {attrs}>` and unescape the value of attribute `key`.
+    fn attr_value(attrs: &str, key: &str) -> String {
+        let start = BytesStart::from_content(format!("e {attrs}"), 1);
+        let attr = start
+            .attributes()
+            .map(|a| a.unwrap())
+            .find(|a| a.key.as_ref() == key.as_bytes())
+            .expect("attribute present");
+        unescape_attr_value(&attr).unwrap()
+    }
+
+    #[test]
+    fn unescapes_predefined_and_numeric_entities() {
+        assert_eq!(attr_value(r#"v="a &amp; b &lt;x&gt; &#65;""#, "v"), "a & b <x> A");
+    }
+
+    #[test]
+    fn passes_plain_value_through_unchanged() {
+        assert_eq!(attr_value(r#"r:id="rId7""#, "r:id"), "rId7");
+    }
+
+    #[test]
+    fn unescapes_ampersand_in_hyperlink_target() {
+        assert_eq!(
+            attr_value(r#"Target="https://x/?a=1&amp;b=2""#, "Target"),
+            "https://x/?a=1&b=2"
+        );
+    }
 }

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide-wasm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) compiled to WebAssembly. Rust core, zero JS dependencies. Works in Node.js, bundlers, and browsers.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",


### PR DESCRIPTION
## Release v0.1.4

Patch release. Bumps every workspace / binding / doc version **0.1.3 → 0.1.4** and ships the quick-xml `encoding`-feature build fix (already on `main` via #63 and #64), plus regression tests.

### Why
`unescape_attr_value` called `Attribute::unescape_value()`, which quick-xml gates behind `#[cfg(not(feature = "encoding"))]`. Cargo feature unification turns `encoding` on transitively whenever a sibling crate enables it (e.g. **calamine ≥ 0.36**), so office_oxide failed to compile with `error[E0599]: no method named unescape_value`. That forced downstreams (e.g. **kreuzberg**) to pin `calamine 0.35`, keeping a vulnerable **quick-xml < 0.41** in the tree (**RUSTSEC-2026-0194 / -0195**, XML DoS).

### What's in it
- **Fix** (from #63 @waxzce and #64 @Goldziher): decode raw attribute bytes as UTF-8 and expand entities via `escape::unescape` — feature-independent, mirrors `unescape_text`.
- **Tests**: entity unescaping in attribute values (predefined + numeric + hyperlink `&amp;`); verified compiling **both** with and without `quick-xml/encoding`.
- **Docs**: note the one deliberate divergence from `unescape_value()` — no XML attribute-value whitespace normalization (irrelevant for real OOXML).
- **Deps**: `zip 8.1 → 8.6` and transitive refreshes (from #64).
- **Version bump**: Cargo (root + cli + mcp), pyproject, js, wasm-pkg, csharp csproj, go install default, and getting-started docs.

### Verification
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets` clean
- `cargo test --lib` → 424 passing (incl. 3 new attr tests)

Closes out the encoding-feature issue for good and lets downstreams move to quick-xml ≥ 0.41.

https://claude.ai/code/session_017tdyrrpR4KkmuLo15S74Zv