### PR TITLE
fix(xlsx): preserve cell attributes and handle self-closing cells in set_cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **XLSX edit: `set_cell` no longer strips a cell's attributes, and no longer deletes the next cell when writing into an empty-but-styled one.** `set_cell_in_xml` rebuilt the `<c>` element from scratch — emitting only `r` and `t` — so every other attribute of the overwritten cell was discarded, most importantly `s`, the style index: a currency or date cell came back with no number format. Worse, the replacement located the end of the cell by searching for `</c>` *before* checking whether the opening tag was self-closing; an empty-but-styled cell is written `<c r="A1" s="5"/>` with no `</c>`, so the search ran on and found the **next** cell's closing tag, and the splice swallowed the cell in between. Both defects converge on the same real workflow — injecting values into a pre-formatted spreadsheet template, whose data rows are made entirely of styled, empty cells: the write silently destroyed a neighbouring cell and stripped the formatting off the one it wrote. `set_cell` now carries every attribute of the existing cell through verbatim (except `r` and `t`, which it owns) and delimits the opening tag before deciding how the element ends.
+
 ## [0.1.6] - 2026-07-13
 
 > Fixes PPTX slides created by `PptxWriter` / `create_from_markdown` rendering blank in LibreOffice Impress.

--- a/src/xlsx/edit.rs
+++ b/src/xlsx/edit.rs
@@ -79,41 +79,111 @@ fn parse_cell_ref(cell_ref: &str) -> Option<(u32, &str)> {
     Some((row, col_str))
 }
 
-/// Set a cell value in worksheet XML by string manipulation.
-/// If the cell already exists, its value is replaced. Otherwise, a new cell is inserted.
-fn set_cell_in_xml(xml: &str, cell_ref: &str, value: &CellValue) -> String {
-    let cell_xml = match value {
-        CellValue::Empty => format!(r#"<c r="{cell_ref}"/>"#),
+/// Collect the attributes of a `<c ...>` opening tag, minus the ones we re-emit.
+///
+/// `r` (the reference) and `t` (the type) are always rewritten from the new value.
+/// Everything else — crucially `s`, the style index, but also `cm`, `vm` and `ph` —
+/// is carried through verbatim, so a written cell keeps its number format, fill and
+/// font instead of coming back unstyled.
+fn preserved_attrs(open_tag: &str) -> String {
+    let body = open_tag
+        .trim_start_matches("<c")
+        .trim_end_matches('>')
+        .trim_end_matches('/');
+
+    let mut out = String::new();
+    let bytes = body.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let name_start = i;
+        while i < bytes.len() && bytes[i] != b'=' && !bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let name = &body[name_start..i];
+
+        while i < bytes.len() && (bytes[i].is_ascii_whitespace() || bytes[i] == b'=') {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'"' {
+            break;
+        }
+        i += 1;
+
+        let value_start = i;
+        while i < bytes.len() && bytes[i] != b'"' {
+            i += 1;
+        }
+        let value = &body[value_start..i.min(body.len())];
+        i += 1;
+
+        if !name.is_empty() && name != "r" && name != "t" {
+            out.push_str(&format!(r#" {name}="{value}""#));
+        }
+    }
+
+    out
+}
+
+/// Render a `<c>` element, carrying the original cell's preserved attributes.
+fn render_cell(cell_ref: &str, attrs: &str, value: &CellValue) -> String {
+    match value {
+        CellValue::Empty => format!(r#"<c r="{cell_ref}"{attrs}/>"#),
         CellValue::String(s) => {
             let escaped = escape_xml(s);
-            format!(r#"<c r="{cell_ref}" t="inlineStr"><is><t>{escaped}</t></is></c>"#)
+            format!(r#"<c r="{cell_ref}"{attrs} t="inlineStr"><is><t>{escaped}</t></is></c>"#)
         },
-        CellValue::Number(n) => format!(r#"<c r="{cell_ref}"><v>{n}</v></c>"#),
+        CellValue::Number(n) => format!(r#"<c r="{cell_ref}"{attrs}><v>{n}</v></c>"#),
         CellValue::Boolean(b) => {
             let v = if *b { "1" } else { "0" };
-            format!(r#"<c r="{cell_ref}" t="b"><v>{v}</v></c>"#)
+            format!(r#"<c r="{cell_ref}"{attrs} t="b"><v>{v}</v></c>"#)
         },
+    }
+}
+
+/// Replace an existing `<c>` element in place, preserving its attributes.
+///
+/// Returns `None` if the cell is not present in `xml`.
+fn replace_existing_cell(xml: &str, cell_ref: &str, value: &CellValue) -> Option<String> {
+    let start = xml.find(&format!(r#"<c r="{cell_ref}""#))?;
+    let rest = &xml[start..];
+
+    // Delimit the OPENING tag first. A cell may be self-closing — `<c r="A1" s="5"/>`,
+    // an empty but styled cell, which is what a pre-formatted template row is made of.
+    // Searching for `</c>` first would run past such a cell and land on the NEXT cell's
+    // closing tag, and the replacement would silently delete the cell in between.
+    let tag_end = rest.find('>')?;
+    let open_tag = &rest[..=tag_end];
+
+    let end = if open_tag.ends_with("/>") {
+        start + tag_end + 1
+    } else {
+        start + rest.find("</c>")? + 4
     };
 
-    // Try to find existing cell with this reference
-    let cell_pattern = format!(r#"<c r="{cell_ref}""#);
-    if let Some(start) = xml.find(&cell_pattern) {
-        // Find end of this cell element
-        let rest = &xml[start..];
-        let end = if let Some(close) = rest.find("</c>") {
-            start + close + 4
-        } else if let Some(close) = rest.find("/>") {
-            start + close + 2
-        } else {
-            return xml.to_string();
-        };
+    let attrs = preserved_attrs(open_tag);
+    let cell_xml = render_cell(cell_ref, &attrs, value);
 
-        let mut result = String::with_capacity(xml.len());
-        result.push_str(&xml[..start]);
-        result.push_str(&cell_xml);
-        result.push_str(&xml[end..]);
-        return result;
+    let mut result = String::with_capacity(xml.len());
+    result.push_str(&xml[..start]);
+    result.push_str(&cell_xml);
+    result.push_str(&xml[end..]);
+    Some(result)
+}
+
+/// Set a cell value in worksheet XML by string manipulation.
+///
+/// If the cell already exists, its value is replaced and its attributes (style, etc.)
+/// are preserved. Otherwise, a new cell is inserted.
+fn set_cell_in_xml(xml: &str, cell_ref: &str, value: &CellValue) -> String {
+    if let Some(replaced) = replace_existing_cell(xml, cell_ref, value) {
+        return replaced;
     }
+
+    let cell_xml = render_cell(cell_ref, "", value);
 
     // Cell doesn't exist — find the right row or create one
     let Some((row, _col)) = parse_cell_ref(cell_ref) else {
@@ -186,6 +256,67 @@ mod tests {
         let xml = r#"<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>"#;
         let result = set_cell_in_xml(xml, "A1", &CellValue::Boolean(true));
         assert!(result.contains(r#"<c r="A1" t="b"><v>1</v></c>"#));
+    }
+
+    #[test]
+    fn set_existing_cell_preserves_style_index() {
+        // `s="5"` is the cell's style: its number format, fill and font. Rebuilding the
+        // <c> element from scratch dropped it, and the written cell came back unstyled.
+        let xml = r#"<sheetData><row r="1"><c r="A1" s="5" t="n"><v>42</v></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "A1", &CellValue::Number(99.0));
+        assert!(result.contains(r#"<c r="A1" s="5"><v>99</v></c>"#), "result: {result}");
+    }
+
+    #[test]
+    fn set_existing_string_cell_preserves_style_index() {
+        let xml = r#"<sheetData><row r="1"><c r="A1" s="3" t="inlineStr"><is><t>old</t></is></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "A1", &CellValue::String("new".into()));
+        assert!(
+            result.contains(r#"<c r="A1" s="3" t="inlineStr"><is><t>new</t></is></c>"#),
+            "result: {result}"
+        );
+    }
+
+    #[test]
+    fn set_existing_cell_preserves_unrelated_attributes() {
+        let xml =
+            r#"<sheetData><row r="1"><c r="A1" s="2" cm="1" vm="4"><v>1</v></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "A1", &CellValue::Number(2.0));
+        assert!(result.contains(r#"s="2""#), "result: {result}");
+        assert!(result.contains(r#"cm="1""#), "result: {result}");
+        assert!(result.contains(r#"vm="4""#), "result: {result}");
+    }
+
+    #[test]
+    fn set_self_closing_cell_does_not_swallow_the_next_cell() {
+        // An empty but STYLED cell is self-closing: `<c r="A1" s="5"/>` — no `</c>`.
+        // Searching for `</c>` first found B1's closing tag instead, and the
+        // replacement deleted B1 along the way. A pre-formatted template row is made
+        // entirely of such cells, so the nominal case triggered the data loss.
+        let xml = r#"<sheetData><row r="1"><c r="A1" s="5"/><c r="B1" s="6"><v>7</v></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "A1", &CellValue::Number(1.0));
+
+        assert!(result.contains(r#"<c r="A1" s="5"><v>1</v></c>"#), "result: {result}");
+        assert!(
+            result.contains(r#"<c r="B1" s="6"><v>7</v></c>"#),
+            "the neighbouring cell must survive; result: {result}"
+        );
+    }
+
+    #[test]
+    fn set_self_closing_cell_to_empty_stays_self_closing() {
+        let xml =
+            r#"<sheetData><row r="1"><c r="A1" s="5"/><c r="B1"><v>7</v></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "A1", &CellValue::Empty);
+        assert!(result.contains(r#"<c r="A1" s="5"/>"#), "result: {result}");
+        assert!(result.contains(r#"<c r="B1"><v>7</v></c>"#), "result: {result}");
+    }
+
+    #[test]
+    fn set_new_cell_carries_no_borrowed_attributes() {
+        let xml = r#"<sheetData><row r="1"><c r="A1" s="9"><v>1</v></c></row></sheetData>"#;
+        let result = set_cell_in_xml(xml, "B1", &CellValue::Number(2.0));
+        assert!(result.contains(r#"<c r="B1"><v>2</v></c>"#), "result: {result}");
     }
 
     #[test]

--- a/tests/write_integration.rs
+++ b/tests/write_integration.rs
@@ -415,6 +415,134 @@ fn xlsx_edit_set_cell_round_trip() {
     assert!(text.contains("Modified"), "text: {text}");
 }
 
+/// Regression: `set_cell` used to rebuild the `<c>` element from scratch, dropping
+/// every attribute of the cell it wrote — including `s`, the style index. A cell that
+/// carried a number format came back naked.
+///
+/// Reproduce on `main` by dropping the `s="5"` assertion's negation: the written cell
+/// is emitted as `<c r="A1"><v>99</v></c>`.
+#[test]
+fn xlsx_edit_set_cell_preserves_cell_style() {
+    let sheet_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData><row r="1"><c r="A1" s="5" t="n"><v>42</v></c></row></sheetData></worksheet>"#;
+
+    let bytes = workbook_with_sheet(sheet_xml);
+    let mut editable = office_oxide::xlsx::edit::EditableXlsx::from_reader(Cursor::new(bytes))
+        .expect("open workbook");
+    editable
+        .set_cell(0, "A1", office_oxide::xlsx::edit::CellValue::Number(99.0))
+        .expect("set cell");
+
+    let mut out = Cursor::new(Vec::new());
+    editable.write_to(&mut out).expect("write");
+    let sheet = read_sheet_xml(out.into_inner());
+
+    assert!(sheet.contains("<v>99</v>"), "sheet: {sheet}");
+    assert!(
+        sheet.contains(r#"s="5""#),
+        "the cell's style index must survive the write; sheet: {sheet}"
+    );
+}
+
+/// Regression: an empty but *styled* cell is self-closing — `<c r="A1" s="5"/>`, with
+/// no `</c>`. `set_cell` searched for `</c>` first, found the **next** cell's closing
+/// tag, and the replacement swallowed the cell in between.
+///
+/// A pre-formatted spreadsheet template is made entirely of such cells, so the nominal
+/// "inject data into a template" case silently destroyed data.
+///
+/// Reproduce on `main`: `B1` is absent from the output.
+#[test]
+fn xlsx_edit_set_self_closing_cell_does_not_delete_the_next_cell() {
+    let sheet_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData><row r="1"><c r="A1" s="5"/><c r="B1" s="6"><v>7</v></c></row></sheetData></worksheet>"#;
+
+    let bytes = workbook_with_sheet(sheet_xml);
+    let mut editable = office_oxide::xlsx::edit::EditableXlsx::from_reader(Cursor::new(bytes))
+        .expect("open workbook");
+    editable
+        .set_cell(0, "A1", office_oxide::xlsx::edit::CellValue::Number(1.0))
+        .expect("set cell");
+
+    let mut out = Cursor::new(Vec::new());
+    editable.write_to(&mut out).expect("write");
+    let sheet = read_sheet_xml(out.into_inner());
+
+    assert!(sheet.contains(r#"<c r="A1" s="5"><v>1</v></c>"#), "sheet: {sheet}");
+    assert!(
+        sheet.contains(r#"<c r="B1" s="6"><v>7</v></c>"#),
+        "the neighbouring cell must survive; sheet: {sheet}"
+    );
+}
+
+/// Minimal OPC package carrying a single worksheet, so the tests above can control the
+/// exact `<c>` shapes they exercise.
+fn workbook_with_sheet(sheet_xml: &str) -> Vec<u8> {
+    use std::io::Write as _;
+    use zip::write::SimpleFileOptions;
+
+    let mut buf = Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let opts = SimpleFileOptions::default();
+
+        let parts = [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#,
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#,
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#,
+            ),
+            ("xl/worksheets/sheet1.xml", sheet_xml),
+        ];
+
+        for (name, body) in parts {
+            zip.start_file(name, opts).expect("start part");
+            zip.write_all(body.as_bytes()).expect("write part");
+        }
+        zip.finish().expect("finish zip");
+    }
+    buf.into_inner()
+}
+
+fn read_sheet_xml(bytes: Vec<u8>) -> String {
+    use std::io::Read as _;
+
+    let mut zip = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+    let mut sheet = String::new();
+    zip.by_name("xl/worksheets/sheet1.xml")
+        .expect("sheet part")
+        .read_to_string(&mut sheet)
+        .expect("read sheet");
+    sheet
+}
+
 #[test]
 fn pptx_edit_replace_text_round_trip() {
     let mut writer = office_oxide::pptx::write::PptxWriter::new();


### PR DESCRIPTION
## Description

Two bugs in `xlsx::edit::set_cell`, both in `set_cell_in_xml`. They are independent, but they converge on the same workflow, so I fixed them together.

**1 — the cell's attributes are dropped.** The `<c>` element is rebuilt from scratch, emitting only `r` and `t`:

```rust
CellValue::Number(n) => format!(r#"<c r="{cell_ref}"><v>{n}</v></c>"#),
```

Every other attribute of the cell being overwritten is discarded. The one that matters is `s`, the style index: write into a currency or date cell and it comes back with no number format. (`cm`, `vm`, `ph` are lost the same way.)

**2 — writing into a self-closing cell deletes the next cell.** The end of the element is located by searching for `</c>` *before* checking whether the opening tag is self-closing:

```rust
let end = if let Some(close) = rest.find("</c>") {   // tried first
    start + close + 4
} else if let Some(close) = rest.find("/>") { ... };
```

An empty-but-styled cell is written `<c r="A1" s="5"/>` — there is no `</c>`. The search runs past it, finds the **next** cell's closing tag, and the splice swallows the cell in between.

Given `<c r="A1" s="5"/><c r="B1" s="6"><v>7</v></c>`, `set_cell(0, "A1", Number(1.0))` currently produces:

```xml
<c r="A1"><v>1</v></c>
```

`B1` is gone, and `A1` lost its style.

**Why both matter, and why they show up together.** The natural use of `EditableXlsx` is injecting values into a pre-formatted spreadsheet template — a workbook someone laid out in Excel, with the data rows already styled and empty. Those rows are made *entirely* of self-closing styled cells. So on the nominal path, a write deleted a neighbouring cell and stripped the formatting off the one it wrote. That is how I found this: I am building a signed-template data bridge on top of `office_oxide` (it was the only library that survived a 34-part torture workbook — pivot tables, slicers, sparklines, charts — without losing or corrupting a part), and the injection quietly ate cells.

**The fix.** `set_cell` now carries every attribute of the existing cell through verbatim — except `r` and `t`, which it owns — and delimits the opening tag *before* deciding how the element ends. New cells still carry no attributes, so nothing is inherited from a neighbour.

Closes #66

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation / tooling / CI only

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Tests added or updated for the changed behaviour
- [x] `cargo test` passes locally
- [x] Documentation updated (public API changes have rustdoc, README updated if needed) — no public API change; the fix is internal to `set_cell_in_xml`
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] All commits include a `Signed-off-by` trailer (`git commit -s`)

## Testing

`cargo test` → **568 passed, 0 failed**. `cargo fmt -- --check`, `cargo clippy --all-targets --workspace -- -D warnings` and `cargo doc --no-deps --workspace` are clean.

**Both bugs are reproducible from the test suite, and both tests fail on `main`.** With the fix reverted and only the tests applied:

```
test xlsx_edit_set_cell_preserves_cell_style ... FAILED
test xlsx_edit_set_self_closing_cell_does_not_delete_the_next_cell ... FAILED
test xlsx_edit_set_cell_round_trip ... ok
test result: FAILED. 36 passed; 2 failed
```

Note the third line: the pre-existing round-trip test passes on `main`. It writes into a cell that has no attributes and is not self-closing, so it cannot see either defect — which is why the suite did not catch them.

The failure output of the second test is the bug, verbatim:

```
sheet: <worksheet ...><sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>
```

Input was `<c r="A1" s="5"/><c r="B1" s="6"><v>7</v></c>`.

Added:

- **6 unit tests** in `src/xlsx/edit.rs` — style index preserved on a number cell and on a string cell; unrelated attributes (`cm`, `vm`) preserved; the self-closing cell does not swallow its neighbour; a self-closing cell set to `Empty` stays self-closing; a *new* cell carries no borrowed attributes.
- **2 integration tests** in `tests/write_integration.rs` — the two above, through the real `EditableXlsx::from_reader → set_cell → write_to` path on an OPC package, re-reading the emitted `xl/worksheets/sheet1.xml`. They need `<c>` shapes `XlsxWriter` does not emit, so they build a minimal 5-part workbook with `zip` (already a dependency of the package, hence available to the test target — no `Cargo.toml` change).

## Notes for reviewers

- **Attribute passthrough is deliberately blind.** `preserved_attrs` copies the opening tag's attributes verbatim, skipping only `r` and `t`. That covers `s`, `cm`, `vm`, `ph` and anything a future `CT_Cell` gains, without this function needing to know the schema. The alternative — an allow-list — silently drops whatever it has not heard of, which is the class of bug being fixed.
- **`t` is dropped on purpose**: the value being written determines the type, so keeping the old cell's `t` would let a number inherit `t="s"` and be read back as a shared-string index.
- I left the string path alone: `CellValue::String` is emitted as `t="inlineStr"` with `<is><t>`, which is valid OOXML and, unlike a shared-strings write, touches no other part. Preserving the attributes does not change that.
- If a maintainer prefers the two fixes as separate commits, I am happy to split them — I kept them together because the self-closing case is only reachable in practice on a styled cell, so they are one story.
