### PR TITLE
release: v0.1.6 — fix PPTX placeholders rendering blank in LibreOffice (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-07-13
+
+> Fixes PPTX slides created by `PptxWriter` / `create_from_markdown` rendering blank in LibreOffice Impress.
+
+### Fixed
+
+- **PPTX placeholder shapes now carry explicit geometry ([#69](https://github.com/yfedoseev/office_oxide/issues/69)).** The generated title and body placeholders previously emitted an empty `<p:spPr/>` with no `<a:xfrm>`, relying on the slide layout for position/size. PowerPoint resolves that from the layout, but LibreOffice Impress does not — so slides rendered blank. The writer now emits an explicit `<a:xfrm>` (offset + extent) on each placeholder, derived from PowerPoint's default Office-theme rectangles and scaled to the presentation size (`set_presentation_size`). Thanks @holgerreppert for the detailed report.
+
 ## [0.1.5] - 2026-07-13
 
 > Dependency-maintenance release. No API or behavior changes — all 424 tests pass and every feature build (default, `parallel`, `mmap`, `python`, `wasm`) compiles clean.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "atoi_simd",
  "encoding_rs",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "office_oxide",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_mcp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "office_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ match_like_matches_macro = "allow"
 manual_find = "allow"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yfedoseev/office_oxide"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let ir = doc.to_ir(); // Format-agnostic intermediate representation
 
 ```toml
 [dependencies]
-office_oxide = "0.1.5"
+office_oxide = "0.1.6"
 ```
 
 ### JavaScript / WASM
@@ -309,7 +309,7 @@ Wheels available for Linux, macOS, and Windows. Python 3.8–3.14.
 
 ```toml
 [dependencies]
-office_oxide = "0.1.5"
+office_oxide = "0.1.6"
 ```
 
 ### JavaScript/WASM

--- a/crates/office_oxide_cli/Cargo.toml
+++ b/crates/office_oxide_cli/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.5", path = "../.." }
+office_oxide = { version = "0.1.6", path = "../.." }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/office_oxide_mcp/Cargo.toml
+++ b/crates/office_oxide_mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.5", path = "../.." }
+office_oxide = { version = "0.1.6", path = "../.." }
 serde_json = "1"
 
 [package.metadata.binstall]

--- a/csharp/OfficeOxide/OfficeOxide.csproj
+++ b/csharp/OfficeOxide/OfficeOxide.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PackageId>OfficeOxide</PackageId>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
     <Title>OfficeOxide</Title>
     <Authors>Yury Fedoseev</Authors>
     <Product>office_oxide</Product>

--- a/docs/getting-started-c.md
+++ b/docs/getting-started-c.md
@@ -67,7 +67,7 @@ LD_LIBRARY_PATH=/usr/local/lib ./quickstart
 ### Library info
 
 ```c
-const char *version = office_oxide_version();           // "0.1.5" — don't free
+const char *version = office_oxide_version();           // "0.1.6" — don't free
 const char *fmt     = office_oxide_detect_format("f"); // "docx"/... or NULL
 ```
 

--- a/docs/getting-started-csharp.md
+++ b/docs/getting-started-csharp.md
@@ -65,7 +65,7 @@ string md   = OfficeOxide.ToMarkdown("file.pptx");
 string html = OfficeOxide.ToHtml("file.xlsx");
 
 string? fmt = Document.DetectFormat("mystery.bin"); // null if unsupported
-Console.WriteLine(Document.Version);                // "0.1.5"
+Console.WriteLine(Document.Version);                // "0.1.6"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-javascript.md
+++ b/docs/getting-started-javascript.md
@@ -92,7 +92,7 @@ extractText('file.docx');      // string
 toMarkdown('file.pptx');       // string
 toHtml('file.xlsx');           // string
 detectFormat('mystery.bin');   // "docx" | ... | null
-version();                     // "0.1.5"
+version();                     // "0.1.6"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-python.md
+++ b/docs/getting-started-python.md
@@ -64,7 +64,7 @@ import office_oxide
 office_oxide.extract_text("file.docx")   # → str
 office_oxide.to_markdown("file.pptx")    # → str
 office_oxide.to_html("file.xlsx")        # → str
-office_oxide.version()                   # → "0.1.5"
+office_oxide.version()                   # → "0.1.6"
 ```
 
 ### `EditableDocument`

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-office_oxide = "0.1.5"
+office_oxide = "0.1.6"
 ```
 
 ### Feature Flags
@@ -16,13 +16,13 @@ office_oxide = "0.1.5"
 ```toml
 [dependencies]
 # Default build — full read/write/edit support for all six formats.
-office_oxide = "0.1.5"
+office_oxide = "0.1.6"
 
 # Memory-mapped opens for large OOXML files.
-office_oxide = { version = "0.1.5", features = ["mmap"] }
+office_oxide = { version = "0.1.6", features = ["mmap"] }
 
 # Parallel parsing helpers.
-office_oxide = { version = "0.1.5", features = ["parallel"] }
+office_oxide = { version = "0.1.6", features = ["parallel"] }
 ```
 
 ## Quickstart

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Bumped in lockstep with the Rust crate.
-const defaultVersion = "0.1.5"
+const defaultVersion = "0.1.6"
 
 const releaseBase = "https://github.com/yfedoseev/office_oxide/releases/download"
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "office-oxide",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "office-oxide",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) for Node.js \u2014 native bindings backed by the Rust office_oxide library.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "office-oxide"
-version = "0.1.5"
+version = "0.1.6"
 description = "The fastest Office document processing library for Python — DOCX, XLSX, PPTX, DOC, XLS, PPT"
 requires-python = ">=3.8"
 license = { text = "MIT OR Apache-2.0" }

--- a/src/pptx/write.rs
+++ b/src/pptx/write.rs
@@ -504,7 +504,7 @@ impl PptxWriter {
                 }
             }
 
-            let slide_xml = generate_slide_xml(slide, &img_rids);
+            let slide_xml = generate_slide_xml(slide, &img_rids, self.cx, self.cy);
             opc.add_part(slide_part, CT_SLIDE, &slide_xml)?;
         }
 
@@ -872,7 +872,12 @@ fn write_layout_placeholder(
 // slides/slideN.xml
 // ---------------------------------------------------------------------------
 
-fn generate_slide_xml(slide: &SlideData, img_rids: &[(String, i64, i64, u64, u64)]) -> Vec<u8> {
+fn generate_slide_xml(
+    slide: &SlideData,
+    img_rids: &[(String, i64, i64, u64, u64)],
+    pres_cx: u64,
+    pres_cy: u64,
+) -> Vec<u8> {
     let mut w = Writer::new(Vec::new());
     write_decl(&mut w);
 
@@ -889,7 +894,7 @@ fn generate_slide_xml(slide: &SlideData, img_rids: &[(String, i64, i64, u64, u64
     let mut next_id: u32 = 2;
 
     if let Some(ref title) = slide.title {
-        write_title_shape(&mut w, next_id, title, slide.title_alignment.as_ref());
+        write_title_shape(&mut w, next_id, title, slide.title_alignment.as_ref(), pres_cx, pres_cy);
         next_id += 1;
     }
 
@@ -899,7 +904,7 @@ fn generate_slide_xml(slide: &SlideData, img_rids: &[(String, i64, i64, u64, u64
             .iter()
             .filter(|i| !matches!(i, BodyItem::TextBox(..) | BodyItem::Image(..)))
             .collect();
-        write_body_shape(&mut w, next_id, &placeholder_items);
+        write_body_shape(&mut w, next_id, &placeholder_items, pres_cx, pres_cy);
         next_id += 1;
     }
 
@@ -927,11 +932,51 @@ fn generate_slide_xml(slide: &SlideData, img_rids: &[(String, i64, i64, u64, u64
     w.into_inner()
 }
 
+// Default placeholder geometry as fractions of slide width/height, derived from
+// PowerPoint's default 16:9 Office theme (title/body rects on a 12192000×6858000
+// slide). We emit these explicitly in each slide's `<p:spPr>` so renderers that
+// don't resolve placeholder geometry from the slide layout — notably LibreOffice
+// Impress — still position title/body text correctly. PowerPoint already resolves
+// from the layout, so this is a no-op there. Fractions keep the geometry correct
+// when the slide size is customised via `set_presentation_size`. See issue #69.
+const TITLE_X_FRAC: f64 = 838_200.0 / 12_192_000.0;
+const TITLE_Y_FRAC: f64 = 365_125.0 / 6_858_000.0;
+const TITLE_CX_FRAC: f64 = 10_515_600.0 / 12_192_000.0;
+const TITLE_CY_FRAC: f64 = 1_325_563.0 / 6_858_000.0;
+const BODY_X_FRAC: f64 = 838_200.0 / 12_192_000.0;
+const BODY_Y_FRAC: f64 = 1_825_625.0 / 6_858_000.0;
+const BODY_CX_FRAC: f64 = 10_515_600.0 / 12_192_000.0;
+const BODY_CY_FRAC: f64 = 4_351_338.0 / 6_858_000.0;
+
+/// Write `<p:spPr>` containing an explicit `<a:xfrm>` with the given EMU
+/// offset/extent. Used for placeholder shapes so their position/size are
+/// self-contained rather than inherited from the layout (see issue #69).
+fn write_sp_pr_with_xfrm(w: &mut Writer<Vec<u8>>, x: i64, y: i64, cx: i64, cy: i64) {
+    w.write_event(Event::Start(BytesStart::new("p:spPr")))
+        .expect("write");
+    w.write_event(Event::Start(BytesStart::new("a:xfrm")))
+        .expect("write");
+    let mut off = BytesStart::new("a:off");
+    off.push_attribute(("x", x.to_string().as_str()));
+    off.push_attribute(("y", y.to_string().as_str()));
+    w.write_event(Event::Empty(off)).expect("write");
+    let mut ext = BytesStart::new("a:ext");
+    ext.push_attribute(("cx", cx.to_string().as_str()));
+    ext.push_attribute(("cy", cy.to_string().as_str()));
+    w.write_event(Event::Empty(ext)).expect("write");
+    w.write_event(Event::End(BytesEnd::new("a:xfrm")))
+        .expect("write");
+    w.write_event(Event::End(BytesEnd::new("p:spPr")))
+        .expect("write");
+}
+
 fn write_title_shape(
     w: &mut Writer<Vec<u8>>,
     id: u32,
     title: &str,
     alignment: Option<&crate::ir::ParagraphAlignment>,
+    pres_cx: u64,
+    pres_cy: u64,
 ) {
     let id_str = id.to_string();
     w.write_event(Event::Start(BytesStart::new("p:sp")))
@@ -960,7 +1005,13 @@ fn write_title_shape(
     w.write_event(Event::End(BytesEnd::new("p:nvSpPr")))
         .expect("write");
 
-    write_empty(w, "p:spPr");
+    write_sp_pr_with_xfrm(
+        w,
+        (pres_cx as f64 * TITLE_X_FRAC) as i64,
+        (pres_cy as f64 * TITLE_Y_FRAC) as i64,
+        (pres_cx as f64 * TITLE_CX_FRAC) as i64,
+        (pres_cy as f64 * TITLE_CY_FRAC) as i64,
+    );
 
     w.write_event(Event::Start(BytesStart::new("p:txBody")))
         .expect("write");
@@ -982,7 +1033,13 @@ fn write_title_shape(
         .expect("write");
 }
 
-fn write_body_shape(w: &mut Writer<Vec<u8>>, id: u32, items: &[&BodyItem]) {
+fn write_body_shape(
+    w: &mut Writer<Vec<u8>>,
+    id: u32,
+    items: &[&BodyItem],
+    pres_cx: u64,
+    pres_cy: u64,
+) {
     let id_str = id.to_string();
     w.write_event(Event::Start(BytesStart::new("p:sp")))
         .expect("write");
@@ -1011,7 +1068,13 @@ fn write_body_shape(w: &mut Writer<Vec<u8>>, id: u32, items: &[&BodyItem]) {
     w.write_event(Event::End(BytesEnd::new("p:nvSpPr")))
         .expect("write");
 
-    write_empty(w, "p:spPr");
+    write_sp_pr_with_xfrm(
+        w,
+        (pres_cx as f64 * BODY_X_FRAC) as i64,
+        (pres_cy as f64 * BODY_Y_FRAC) as i64,
+        (pres_cx as f64 * BODY_CX_FRAC) as i64,
+        (pres_cy as f64 * BODY_CY_FRAC) as i64,
+    );
 
     w.write_event(Event::Start(BytesStart::new("p:txBody")))
         .expect("write");
@@ -1306,6 +1369,53 @@ mod tests {
         let mut xml = String::new();
         std::io::Read::read_to_string(&mut entry, &mut xml).unwrap();
         assert!(xml.contains("cx=\"9144000\""), "expected cx in presentation.xml");
+    }
+
+    /// Read `ppt/slides/slide1.xml` from a written presentation.
+    fn slide1_xml(writer: PptxWriter) -> String {
+        let mut buf = Cursor::new(Vec::new());
+        writer.write_to(&mut buf).unwrap();
+        buf.set_position(0);
+        let mut zip = zip::ZipArchive::new(buf).unwrap();
+        let mut entry = zip.by_name("ppt/slides/slide1.xml").unwrap();
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut entry, &mut xml).unwrap();
+        xml
+    }
+
+    /// Regression for issue #69: placeholder title/body shapes must carry an
+    /// explicit `<a:xfrm>` (off + ext) so LibreOffice, which doesn't resolve
+    /// placeholder geometry from the layout, renders their text.
+    #[test]
+    fn placeholders_have_explicit_xfrm() {
+        let mut writer = PptxWriter::new();
+        writer.add_slide().set_title("Hello").add_text("World");
+        let xml = slide1_xml(writer);
+
+        // No empty <p:spPr/> — every shape now carries geometry.
+        assert!(
+            !xml.contains("<p:spPr/>") && !xml.contains("<p:spPr></p:spPr>"),
+            "placeholder shapes must not have empty spPr:\n{xml}"
+        );
+        // Title + body placeholders present, each with an xfrm.
+        assert!(xml.contains(r#"<p:ph type="title"/>"#));
+        assert!(xml.contains(r#"<p:ph type="body""#));
+        assert_eq!(xml.matches("<a:xfrm>").count(), 2, "one xfrm per placeholder");
+        // Default 16:9 title offset/extent (from PowerPoint Office theme).
+        assert!(xml.contains(r#"<a:off x="838200" y="365125"/>"#), "title off:\n{xml}");
+        assert!(xml.contains(r#"<a:ext cx="10515600" cy="1325563"/>"#), "title ext");
+    }
+
+    /// Placeholder geometry scales with a custom presentation size.
+    #[test]
+    fn placeholder_xfrm_scales_with_presentation_size() {
+        let mut writer = PptxWriter::new();
+        writer.set_presentation_size(9_144_000, 6_858_000); // 4:3
+        writer.add_slide().set_title("T").add_text("B");
+        let xml = slide1_xml(writer);
+        // Title x = 9144000 * (838200/12192000) = 628650
+        assert!(xml.contains(r#"<a:off x="628650""#), "scaled title off:\n{xml}");
+        assert!(!xml.contains("<p:spPr/>"));
     }
 
     #[test]

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide-wasm",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) compiled to WebAssembly. Rust core, zero JS dependencies. Works in Node.js, bundlers, and browsers.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",


### PR DESCRIPTION
## Release v0.1.6

Fixes [#69](https://github.com/yfedoseev/office_oxide/issues/69) — PPTX slides created by `PptxWriter` / `create_from_markdown` render **blank in LibreOffice Impress**.

### Root cause
The generated title/body placeholder shapes emitted an empty `<p:spPr/>` with no `<a:xfrm>`, relying on the slide **layout** for position/size. PowerPoint resolves placeholder geometry from the layout (renders fine), but **LibreOffice Impress does not** — so the text had no box and rendered off-slide/blank.

### Fix
Emit an explicit `<a:xfrm>` (offset + extent) on each placeholder shape, derived from PowerPoint's default Office-theme rectangles and **scaled to the presentation size**, so it stays correct when `set_presentation_size()` is used. Matches the reporter's preferred fix (option 1/3).

Before → after (title placeholder):
```xml
<p:spPr/>
<!-- becomes -->
<p:spPr><a:xfrm><a:off x="838200" y="365125"/><a:ext cx="10515600" cy="1325563"/></a:xfrm></p:spPr>
```

### Tests
- `placeholders_have_explicit_xfrm` — asserts no empty `<p:spPr/>`, one `<a:xfrm>` per placeholder, correct default 16:9 geometry.
- `placeholder_xfrm_scales_with_presentation_size` — verifies geometry scales for a 4:3 slide.
- Verified on a real generated `.pptx`: both placeholders now carry `<a:xfrm>`.

### Verification
- `cargo fmt --check` clean · `cargo clippy --workspace --all-targets` clean · `cargo test --lib` → **426 pass**.

Version bumped 0.1.5 → 0.1.6. Closes #69. Thanks @holgerreppert for the precise report.

https://claude.ai/code/session_017tdyrrpR4KkmuLo15S74Zv