### PR TITLE
fix(xlsx): cap worksheet rows materialised into the IR

### DIFF
--- a/src/convert_xlsx.rs
+++ b/src/convert_xlsx.rs
@@ -1,6 +1,15 @@
 use crate::format::DocumentFormat;
 use crate::ir::*;
 
+/// Maximum worksheet rows materialised into the IR per sheet. A worksheet is
+/// converted eagerly into an in-memory `Table` (or one `Paragraph` per row),
+/// and downstream a single table cannot render to an unbounded PDF, so an
+/// uncapped sheet (e.g. a 200k-row stress fixture) explodes memory and stalls
+/// rendering. Beyond this many rows the remainder is dropped and a visible
+/// truncation notice is appended, rather than hanging. Chosen to preserve
+/// ordinary large spreadsheets while bounding pathological ones.
+const MAX_ROWS_PER_SHEET: usize = 10_000;
+
 /// Parse a 6-char hex colour like `"FFA500"` into `[r, g, b]`.
 fn parse_hex_rgb(s: &str) -> Option<[u8; 3]> {
     let s = s.trim_start_matches('#');
@@ -28,8 +37,13 @@ pub(crate) fn xlsx_to_ir(doc: &crate::xlsx::XlsxDocument) -> DocumentIR {
         // string plus the structured facts (semantic type, raw value, number
         // format) that the grid path threads into the IR so `to_ir()`
         // consumers can tell numbers/dates from text (issue #72).
-        let mut parsed_rows: Vec<Vec<CellData>> = Vec::with_capacity(ws.rows.len());
-        for row in &ws.rows {
+        // Cap eager row materialisation: an unbounded sheet would build
+        // millions of IR cell allocations and then stall the single-table
+        // render downstream. Excess rows are dropped and flagged below.
+        let total_rows = ws.rows.len();
+        let mut parsed_rows: Vec<Vec<CellData>> =
+            Vec::with_capacity(total_rows.min(MAX_ROWS_PER_SHEET));
+        for row in ws.rows.iter().take(MAX_ROWS_PER_SHEET) {
             let mut cells: Vec<CellData> = Vec::with_capacity(row.cells.len());
             for cell in &row.cells {
                 buf.clear();
@@ -275,6 +289,20 @@ pub(crate) fn xlsx_to_ir(doc: &crate::xlsx::XlsxDocument) -> DocumentIR {
         // first). Empty `image_elements` means no drawing on this sheet.
         let mut combined: Vec<Element> = image_elements;
         combined.extend(elements);
+
+        // Graceful truncation notice: when the sheet exceeded the row cap,
+        // the dropped rows are not silently lost — a visible paragraph records
+        // how many rows were omitted so downstream text/markdown/PDF makes the
+        // truncation obvious rather than appearing complete.
+        if total_rows > MAX_ROWS_PER_SHEET {
+            let omitted = total_rows - MAX_ROWS_PER_SHEET;
+            combined.push(Element::Paragraph(Paragraph {
+                content: vec![InlineContent::Text(TextSpan::plain(format!(
+                    "[{omitted} of {total_rows} rows not shown — worksheet truncated at {MAX_ROWS_PER_SHEET} rows]"
+                )))],
+                ..Default::default()
+            }));
+        }
 
         sections.push(Section {
             title: Some(ws.name.clone()),

--- a/tests/xlsx_row_cap.rs
+++ b/tests/xlsx_row_cap.rs
@@ -1,0 +1,105 @@
+//! An XLSX worksheet with more rows than the IR cap must be truncated (with a
+//! visible notice) instead of building an unbounded IR that stalls rendering,
+//! while ordinary sheets are unaffected.
+
+use office_oxide::ir::{
+    Element, InlineContent, Metadata, Paragraph, Section, Table, TableCell, TableRow, TextSpan,
+};
+use office_oxide::{Document, DocumentFormat, DocumentIR, create};
+use std::io::Cursor;
+
+const CAP: usize = 10_000;
+
+fn cell(text: &str) -> TableCell {
+    TableCell {
+        content: vec![Element::Paragraph(Paragraph {
+            content: vec![InlineContent::Text(TextSpan::plain(text.to_string()))],
+            ..Default::default()
+        })],
+        ..Default::default()
+    }
+}
+
+/// Build an XLSX (via the IR writer) with `n` two-column rows, then read it
+/// back to an IR through the capped `xlsx_to_ir` path.
+fn roundtrip_sheet(n: usize) -> DocumentIR {
+    let rows: Vec<TableRow> = (0..n)
+        .map(|i| TableRow {
+            cells: vec![cell(&format!("a{i}")), cell(&format!("b{i}"))],
+            ..Default::default()
+        })
+        .collect();
+    let ir = DocumentIR {
+        metadata: Metadata {
+            format: DocumentFormat::Xlsx,
+            ..Default::default()
+        },
+        sections: vec![Section {
+            title: Some("Sheet1".to_string()),
+            elements: vec![Element::Table(Table {
+                rows,
+                ..Default::default()
+            })],
+            ..Default::default()
+        }],
+    };
+    let mut buf = Cursor::new(Vec::new());
+    create::create_from_ir_to_writer(&ir, DocumentFormat::Xlsx, &mut buf).unwrap();
+    buf.set_position(0);
+    Document::from_reader(buf, DocumentFormat::Xlsx)
+        .unwrap()
+        .to_ir()
+}
+
+fn table_row_count(ir: &DocumentIR) -> usize {
+    ir.sections
+        .iter()
+        .flat_map(|s| &s.elements)
+        .find_map(|e| match e {
+            Element::Table(t) => Some(t.rows.len()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+#[test]
+fn oversized_sheet_is_capped_with_notice() {
+    // 5 rows over the cap. This also completes quickly, demonstrating the sheet
+    // no longer builds an unbounded IR.
+    let ir = roundtrip_sheet(CAP + 5);
+    assert_eq!(table_row_count(&ir), CAP, "table should be capped at {CAP} rows");
+    let text = ir
+        .sections
+        .iter()
+        .flat_map(|s| &s.elements)
+        .filter_map(|e| match e {
+            Element::Paragraph(p) => Some(
+                p.content
+                    .iter()
+                    .filter_map(|c| match c {
+                        InlineContent::Text(t) => Some(t.text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>(),
+            ),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        text.contains("not shown") && text.contains("truncated"),
+        "a truncation notice must be present, got: {text:?}"
+    );
+}
+
+#[test]
+fn ordinary_sheet_is_untouched() {
+    let ir = roundtrip_sheet(5);
+    assert_eq!(table_row_count(&ir), 5, "small sheet must keep all rows");
+    let has_notice = ir
+        .sections
+        .iter()
+        .flat_map(|s| &s.elements)
+        .any(|e| matches!(e, Element::Paragraph(p) if p.content.iter().any(|c| matches!(c, InlineContent::Text(t) if t.text.contains("not shown")))));
+    assert!(!has_notice, "small sheet must not carry a truncation notice");
+}


### PR DESCRIPTION
## Summary

`xlsx_to_ir` (`src/convert_xlsx.rs`) materialised **every** worksheet row into an in-memory IR with no bound. A pathological sheet (e.g. the 200k-row `tika_testRecordSizeExceeded.xlsx` stress fixture) built millions of cell allocations and then **stalled the downstream single-table PDF render** — a table can't render to an unbounded number of pages. This is the hang reported in #29.

## Fix

- Cap materialisation at `MAX_ROWS_PER_SHEET = 10_000` rows per sheet (`ws.rows.iter().take(MAX_ROWS_PER_SHEET)`).
- When a sheet exceeds the cap, append a **visible truncation notice** paragraph (`"N of M rows not shown — worksheet truncated at 10000 rows"`) so the omission is obvious in text/markdown/PDF output rather than silent — graceful degradation, not a hang.
- Ordinary spreadsheets (≤ cap) are byte-for-byte unaffected.

The per-cell allocation note in the same issue is **already addressed** on `main`: `xlsx_to_ir` uses `write_cell_value_fast(cell, &mut buf, …)` with a single reused `String` buffer, so the `format_cell_value`-per-cell allocation the issue described no longer exists.

## Scope note

This bounds the office_oxide extraction side. The complementary work — paginating a large table across PDF pages in pdf_oxide's `render_table()` (option 3 in the issue) — is a separate pdf_oxide change and out of scope here.

## Tests (`tests/xlsx_row_cap.rs`)

- `oversized_sheet_is_capped_with_notice` — a 10,005-row sheet round-trips to exactly 10,000 rows + a truncation notice, and **completes in <1s** (demonstrating it no longer builds an unbounded IR).
- `ordinary_sheet_is_untouched` — a 5-row sheet keeps all rows and carries no notice.

Existing `xlsx_integration` (17), `write_integration` (38), `core_integration` (16) remain green. `cargo fmt` ✅ · `cargo clippy` ✅

Closes #29