### PR TITLE
chore: harden CI + IP governance (Scorecard fuzz/permissions + CLA/trademark/NOTICE)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,72 @@
-## Description
+<!--
+Read CONTRIBUTING.md first. The two rules that matter most:
+  1. Non-trivial PRs must reference an issue the maintainer has ACCEPTED.
+     Drive-by PRs with no accepted issue may be closed without detailed review.
+  2. Any parsing/extraction/IR change must be proven not to regress on a corpus
+     of real Office files (yours — the project corpus is private).
+Write this PR in your own words. Delete the guidance comments as you fill it in.
 
-<!-- What does this PR do? Why? Link to the issue it resolves if applicable. -->
+NOTE: a PR opened without filling in this template is closed automatically —
+just fill it in and reopen. (Maintainers, drafts, and `skip-template-check` are
+exempt.)
+-->
 
+## Linked issue
+
+<!-- Required for features/behavior changes. Bug/typo/docs fixes may omit. -->
 Closes #
+
+## What and why
+
+<!-- In your own words: what problem does this solve, and why this approach? -->
 
 ## Type of change
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation / tooling / CI only
+- [ ] Bug fix
+- [ ] New feature (has an accepted issue: #___)
+- [ ] Performance
+- [ ] Refactor / internal
+- [ ] Docs / CI / chore
+- [ ] Breaking change
+
+## Tests
+
+- [ ] I added a test that **fails before this change and passes after**
+      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
+      document built in code** where practical — no third-party/customer file is
+      committed.
+- [ ] Test named by defect **class**, not an issue/PR number; no
+      contributor/company names in code or fixtures.
+- [ ] `cargo test` passes, plus the affected feature tiers / bindings: ____
+- [ ] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.
+
+## Regression on real Office files
+
+<!-- Required for ANY parsing / extraction / IR change.
+     The project corpus is private; use your OWN corpus. -->
+
+**Corpus I tested** (count + kinds + source): <!-- e.g. "~80 files: docx/xlsx/pptx
++ a few legacy .doc/.xls, real-world, from my own collection" -->
+
+- [ ] Ran the extraction over my corpus on my branch vs **main** — no unintended
+      regressions (no dropped content, garbled text, or crashes).
+- [ ] Checked against the **latest release** as well.
+
+**Diff summary:** <!-- what changed, and confirmation it's only the intended fix -->
+
+<!-- N/A only if this PR touches no parsing/extraction/IR code. -->
+
+## AI assistance disclosure
+
+- [ ] AI assistance: **none**, or **assisted** — tool: ______, extent: ______
+- [ ] I understand and can explain every line; the description and my review
+      replies are written by me, not generated. This PR is not fully or
+      predominantly AI-generated.
 
 ## Checklist
 
-- [ ] `cargo fmt -- --check` passes
-- [ ] `cargo clippy --all-targets -- -D warnings` passes
-- [ ] Tests added or updated for the changed behaviour
-- [ ] `cargo test` passes locally
-- [ ] Documentation updated (public API changes have rustdoc, README updated if needed)
-- [ ] `CHANGELOG.md` updated under `[Unreleased]`
-- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
-
-## Testing
-
-<!-- Describe how you tested this change. Include relevant commands or output snippets. -->
-
-## Notes for reviewers
-
-<!-- Anything the reviewer should pay special attention to, known limitations, or follow-up work. -->
+- [ ] One logical change (no bundled refactor/perf/correctness).
+- [ ] Commits follow Conventional Commits.
+- [ ] Non-trivial contribution: I will sign the CLA when the bot asks (see CLA.md).
+- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
+      CHANGELOG (not in code).

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,50 @@
+# Contributor License Agreement bot (CLA Assistant Lite).
+#
+# Runs entirely in this repo — no external SaaS. Signatures are stored in this
+# repo on the `cla-signatures` branch, so it needs ONLY the built-in
+# GITHUB_TOKEN (with contents: write), the same mechanism the release workflow
+# already uses to push git tags. No PERSONAL_ACCESS_TOKEN is required (that is
+# only needed when signatures live in a *different* repository).
+#
+# On a non-trivial contributor's PR the bot comments asking them to sign; they
+# reply with the sign phrase and the bot records their GitHub username in
+# signatures/cla.json and turns the CLA check green. The maintainer and bots are
+# allowlisted so they are never asked. See CLA.md for the agreement text.
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write        # create/update signatures/cla.json (same-repo storage)
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    # Only act on PR events or on the sign / recheck comment phrases — not on
+    # every comment in the tracker.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == 'recheck' ||
+         contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
+    steps:
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/yfedoseev/office_oxide/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          # Maintainer + bots never need to sign.
+          allowlist: 'yfedoseev,dependabot[bot],github-actions[bot],bot*'

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,98 @@
+# Deterministic PR-quality gates — no LLM/agent judgment, pure rule checks.
+# These substitute for the human reviewer a solo maintainer doesn't have:
+#   - title:     PR title must follow Conventional Commits (load-bearing for squash-merge)
+#   - no-binary: block committed compiled/library artifacts (reinforces Binary-Artifacts + fixture policy)
+#   - ai-label:  label (never block) PRs whose commits disclose AI co-authorship
+#
+# Security: uses `pull_request_target` for write access on fork PRs, but only
+# reads strings from the event payload / REST API via github-script and never
+# checks out or runs PR code, and never interpolates untrusted input into a
+# shell — so there is no injection surface (only integer PR numbers appear in
+# `${{ }}`).
+name: PR quality gates
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-quality-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    name: PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+            const conventional = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9,\-_ /]+\))?!?: .+/;
+            const release = /^Release v?\d+\.\d+/;   // maintainer release PRs
+            if (conventional.test(title) || release.test(title)) return;
+            core.setFailed(
+              'PR title must follow Conventional Commits — e.g. "fix(text): …", "feat: …", ' +
+              '"docs: …" (or a "Release vX.Y.Z …" title). Got: "' + title + '"'
+            );
+
+  no-binary:
+    name: No compiled / binary artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            // Compiled libraries / bytecode / executables — build from source,
+            // ship from source / release assets. (Office documents like .docx/.xlsx
+            // and fonts/images remain allowed — only compiled artifacts are blocked.)
+            const disallowed = /\.(so|dll|dylib|a|rlib|o|class|pyc|pyo|exe|wasm|jar|node|dSYM)$/i;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const offenders = files
+              .filter(f => f.status === 'added' && disallowed.test(f.filename))
+              .map(f => f.filename);
+            if (offenders.length) {
+              core.setFailed(
+                'These compiled/binary artifacts must not be committed:\n' +
+                offenders.map(f => '  - ' + f).join('\n')
+              );
+            }
+
+  ai-label:
+    name: Label AI-assisted contributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            // Label (never block) — disclosed AI co-authorship is legitimate;
+            // this is for reviewer routing/metrics. Catches only *disclosed* AI
+            // (trailers / an Assisted-by line); undisclosed use is undetectable.
+            const marker = /(co-authored-by:[^\n]*(claude|copilot|cursor|devin|chatgpt|gpt|gemini|codex)|assisted-by:)/i;
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const body = context.payload.pull_request.body || '';
+            const disclosed = marker.test(body) || commits.some(c => marker.test(c.commit.message || ''));
+            if (!disclosed) return;
+            const common = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            };
+            const existing = (await github.rest.issues.listLabelsOnIssue(common)).data.map(l => l.name);
+            if (!existing.includes('ai-assisted')) {
+              await github.rest.issues.addLabels({ ...common, labels: ['ai-assisted'] });
+            }

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,6 +17,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default token (OpenSSF Scorecard Token-Permissions). Jobs
+# opt into wider scopes only where they actually need them.
+permissions:
+  contents: read
+
 jobs:
   # Test job - builds extension and runs tests
   test:

--- a/.github/workflows/template-compliance.yml
+++ b/.github/workflows/template-compliance.yml
@@ -1,0 +1,77 @@
+# Auto-close issues and pull requests that ignore the templates.
+#
+# Enforcement is deliberately narrow: we only auto-close when the body is
+# effectively EMPTY once the template scaffolding (guidance comments, headings,
+# checkboxes, empty "Closes #") is stripped — i.e. the reporter opened the form
+# and submitted it without filling anything in. A contributor who fills in the
+# template is never touched. Maintainers, drafts, and anything labelled
+# `skip-template-check` are exempt. A closed item can be edited and reopened.
+#
+# Security: this uses `pull_request_target` (needed for write access on PRs from
+# forks) but ONLY reads strings from the event payload via github-script and
+# calls the issues/pulls API. It never checks out or executes PR code, and never
+# interpolates untrusted text into a shell — so there is no injection surface.
+name: Template compliance
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: template-compliance-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const item = context.payload.pull_request || context.payload.issue;
+            if (!item || item.state !== 'open') return;
+
+            // --- exemptions -------------------------------------------------
+            if (isPR && item.draft) return;                      // WIP drafts
+            const assoc = item.author_association;
+            if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc)) return; // maintainers
+            const labels = (item.labels || []).map(l => (l.name || l).toLowerCase());
+            if (labels.includes('skip-template-check')) return;  // manual bypass
+
+            // --- is the template effectively unfilled? ----------------------
+            const stripped = (item.body || '')
+              .replace(/<!--[\s\S]*?-->/g, '')                   // guidance comments
+              .split('\n')
+              .filter(line => {
+                const s = line.trim();
+                if (!s) return false;                            // blank
+                if (/^#{1,6}\s/.test(s)) return false;           // md / issue-form headings
+                if (/^-\s*\[[ xX]\]/.test(s)) return false;      // checkboxes
+                if (/^(closes|fixes|resolves)\s*#?\s*$/i.test(s)) return false; // empty "Closes #"
+                if (/^_no response_$/i.test(s)) return false;    // empty issue-form optional
+                return true;
+              })
+              .join('\n')
+              .trim();
+
+            if (stripped.length > 0) return;                     // they filled something in — OK
+
+            // --- close with a friendly, actionable explanation --------------
+            const kind = isPR ? 'pull request' : 'issue';
+            const body = [
+              `Thanks for opening this. It looks like the ${kind} template wasn't filled in, so it was closed automatically — this keeps the tracker reviewable (see CONTRIBUTING.md).`,
+              '',
+              `Please **edit** this ${kind} to fill in the template, then **reopen** it and we'll pick it up. If you think this was a mistake, add the \`skip-template-check\` label or ping a maintainer.`,
+            ].join('\n');
+
+            const common = { owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number };
+            await github.rest.issues.createComment({ ...common, body });
+            await github.rest.issues.update({ ...common, state: 'closed', state_reason: 'not_planned' });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md — guidance for AI coding agents
+
+OfficeOxide is a pure-Rust parser/extractor for Office documents — OOXML
+(`.docx`/`.xlsx`/`.pptx`, a zip of XML) and the legacy CFB compound formats
+(`.doc`/`.xls`/`.ppt`). Read [`CONTRIBUTING.md`](CONTRIBUTING.md) in full before
+proposing changes. The essentials that apply to agent-assisted work:
+
+## Contribution rules (must follow)
+
+1. **Issue-first.** Non-trivial changes require an issue the maintainer has
+   accepted, with the approach agreed *before* code is written. Do not open
+   drive-by PRs — they may be closed without review. Bug/typo/docs fixes may
+   skip this; the reproducer may not.
+2. **No autonomous PRs.** An autonomous agent must not open issues or pull
+   requests on its own. A human directs the work, reviews every line, and is
+   accountable for it. Disclose AI assistance in the PR; the human owns
+   correctness, licensing, and provenance. Non-trivial contributions are signed
+   under the project's [CLA](CLA.md).
+3. **The human must understand and be able to explain every line.** If the
+   change can't be explained without the AI, it isn't ready.
+4. **Every bug fix ships a regression test that fails before the fix.** Build the
+   reproducer as a **minimal synthetic document in code** where practical (a
+   small OOXML part or CFB stream) — do not commit third-party/customer/real
+   documents that you don't have the rights to redistribute.
+5. **Prove no corpus regression.** Office parsers consume untrusted input;
+   heuristics regress silently. For any change to parsing/extraction/IR, run the
+   test suite **and** your own corpus of representative real `.docx/.xlsx/.pptx/
+   .doc/.xls/.ppt` files (the project's corpus is not distributed — bring your
+   own), and report what you tested in the PR.
+6. **Robustness contract:** no input may panic, overflow, or hang. Malformed
+   documents (bad zip central directory, cyclic OPC relationships, bogus CFB
+   FAT chains, oversized dimensions) must surface as `Err`, not a crash. A fuzz
+   target lives in `fuzz/` — extend it when you touch a parser.
+7. **House rules:** no issue/PR numbers or contributor/company names in code,
+   comments, or fixture names — name tests by defect *class*; credit reporters
+   only in `CHANGELOG.md`. One logical change per PR. Fail loudly, never fall
+   back to a silent plausible-but-wrong result.
+8. **Green across the feature matrix**, not just the default `cargo test` — run
+   the tiers your change touches (bindings, optional features).
+
+## Format references
+- **OOXML** — ECMA-376 / ISO/IEC 29500 (Office Open XML): the `.docx/.xlsx/.pptx`
+  package is an OPC (Open Packaging Conventions) zip of parts + relationships.
+- **CFB** — MS-CFB (Compound File Binary) underlies the legacy `.doc/.xls/.ppt`.
+- Prefer spec-accurate parsing over guessing; when a document violates the spec,
+  degrade gracefully with a warning rather than a panic.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,103 @@
+# Contributor License Agreement (CLA)
+
+> **Status / legal note.** This CLA is adapted from the widely-used
+> **Apache Software Foundation Individual & Corporate CLA (v2.0)**. It is a
+> **licence**, not a copyright assignment — you keep ownership of your
+> contribution and simply grant the project a broad licence to use and
+> sub-licence it. **Some items still need counsel before you rely on this for
+> enforcement or an acquisition** — in particular the *governing law / venue*
+> (§7, left blank), whether to register the trademark, and the enforceability of
+> the click-through signature. **Enable a CLA bot (e.g.
+> [CLA assistant](https://github.com/cla-assistant/cla-assistant)) to record
+> signatures — ideally before accepting substantial contributions**, so the
+> clean relicense right and patent grant attach from day one. Until the bot is
+> enabled, the [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) is the
+> operative requirement.
+
+Thank you for contributing to **OfficeOxide** (the "Project"; distributed as the
+`office_oxide` packages/crate, maintained by the Project's copyright holder, the
+"Maintainer"). To keep the Project's licensing clean and its future options
+open, contributors of non-trivial changes agree to the terms below. You retain
+all right, title, and interest in your Contributions.
+
+By submitting a Contribution (a pull request, patch, or other work) to the
+Project, **You** accept and agree to the following for present and future
+Contributions submitted to the Project.
+
+## 1. Definitions
+- **"You"** means the individual or legal entity making a Contribution.
+- **"Maintainer"** means Yury Fedoseev **and his successors and assigns.** The
+  Maintainer may **assign or transfer** its rights and licences under this CLA,
+  in whole or in part, without further consent from You (for example, in
+  connection with a sale, merger, or transfer of the Project).
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that You intentionally submit to
+  the Project for inclusion.
+
+## 2. Copyright licence
+You grant the Maintainer and recipients of software distributed by the Project a
+**perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+licence** to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, **and distribute Your Contributions and such derivative
+works — under any licence terms, including the Project's current
+`MIT OR Apache-2.0` terms and any future licence the Maintainer chooses.**
+(This sub-licensing right is what preserves the Project's ability to relicense
+future versions; it does not affect already-published releases, which remain
+under their original terms forever.)
+
+## 3. Patent licence
+You grant the Maintainer and recipients of the Project a **perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable (except as below) patent licence** to
+make, have made, use, offer to sell, sell, import, and otherwise transfer Your
+Contribution, where such licence applies only to those patent claims licensable
+by You that are necessarily infringed by Your Contribution alone or by
+combination of Your Contribution with the Project. If any entity institutes
+patent litigation **(including a cross-claim or counterclaim in a lawsuit)**
+alleging that Your Contribution, or the Project to which You contributed,
+constitutes direct or contributory patent infringement, then any patent licences
+granted to that entity under this CLA terminate **as of the date such litigation
+is filed.**
+
+## 4. Your representations
+You represent that:
+- Each Contribution is **Your original creation** and You have the legal right to
+  grant the above licences.
+- If Your employer has rights to intellectual property You create, You have
+  received permission to make the Contribution on behalf of that employer, or the
+  employer has waived such rights, or the employer has executed the corporate
+  version of this CLA.
+- Each Contribution does **not** knowingly include third-party code under an
+  incompatible licence (e.g. GPL/AGPL) or otherwise violate any third party's
+  rights. Any third-party material is identified and its licence noted.
+- You are not aware of any patents or other rights that would make the licences
+  above impossible to grant.
+- You agree to **notify the Maintainer** if You later become aware of any fact
+  that would make any representation above inaccurate.
+- To the extent permitted by applicable law, You **waive, and agree not to
+  assert, any moral rights** in Your Contributions against the Maintainer and
+  downstream recipients, to the extent necessary to exercise the licences granted
+  above.
+
+## 5. Support & warranty
+You are not expected to provide support for Your Contributions. Contributions are
+provided **"as is"**, without warranties or conditions of any kind, except as
+stated in Section 4.
+
+## 6. How to sign
+- **Individuals:** once the CLA bot is enabled, it will comment on your first pull
+  request with a one-click sign-off link; signing is required before merge.
+- **On behalf of a company (Corporate CLA):** have an authorized signatory
+  contact the Maintainer at **yfedoseev@gmail.com** to record the entity and its
+  authorized contributors.
+
+Trivial changes (typo fixes, formatting, documentation-only edits) do not require
+a CLA. The [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) is still
+required on every commit.
+
+## 7. Miscellaneous
+This CLA is effective on the date You first submit a Contribution and covers all
+present and future Contributions. The Maintainer is **under no obligation** to
+use, merge, or distribute any Contribution. This CLA is the **entire agreement**
+between You and the Maintainer regarding Your Contributions and supersedes any
+prior understanding on that subject. **Governing law:** _to be set by the
+Maintainer's counsel before enforcement._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,11 +339,13 @@ git commit -s -m "feat(docx): add heading extraction"
 # Produces: Signed-off-by: Your Name <you@example.com>
 ```
 
-This is checked automatically on every pull request by the DCO CI job. There is no CLA to sign — the sign-off is all that's required.
+This is checked automatically on every pull request by the DCO CI job.
+
+**CLA** — non-trivial contributions are also accepted under the project's [Contributor License Agreement](CLA.md). It is a *licence, not an assignment*: you keep ownership and grant the project a broad copyright + patent licence including the right to relicense future versions. Trivial changes (typos, formatting, docs) are exempt. Once the CLA bot is enabled it records your one-click sign-off on your first PR; until then the DCO sign-off above is the operative requirement.
 
 ## License
 
-By contributing, you agree that your contributions will be dual licensed under **MIT OR Apache-2.0**, without any additional terms or conditions.
+By contributing, you agree that the **outbound licence for released code is MIT OR Apache-2.0** (inbound = outbound for what ships to users). In addition, **non-trivial contributions are made under the project's [Contributor License Agreement](CLA.md)**, which grants the Maintainer a broader, sub-licensable copyright and patent licence so the project can relicense *future* versions if needed. The CLA does not change the licence of any already-published release. Trivial changes are exempt and remain inbound = outbound only.
 
 This means:
 - Your code will be available under permissive open-source licenses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,36 @@
 
 Thank you for your interest in contributing! This document provides guidelines and information for contributors.
 
+## The rules that matter most
+
+These apply to **everyone, including the maintainer** — office_oxide is a
+correctness-critical parser, and a subtle regression can silently corrupt output
+for many documents.
+
+1. **Open or find an accepted issue before non-trivial work**, and agree the
+   approach there first. **Drive-by pull requests with no linked, accepted issue
+   may be closed without detailed review.** Bug/typo/docs fixes are exempt.
+2. **Any change to parsing, extraction, or the document IR must be proven not to
+   regress on real Office files.** These paths are heuristic and fail silently.
+   Ship a minimal synthetic reproducer (in code) for every bug fix, and run your
+   **own** corpus of real `.docx/.xlsx/.pptx/.doc/.xls/.ppt` (the project corpus
+   is private, not distributed) — report what you tested in the PR, vs both
+   `main` and the latest release.
+
+### Contribution quality & AI-assisted work
+Maintainer review time is the scarcest resource — a contribution must be worth
+more than the time it takes to review it. We are not anti-AI; we are anti-slop.
+- **You are responsible for everything you submit**, including code an AI wrote —
+  licence, correctness, provenance. You must be able to **explain every line**.
+- **Write issues, PR descriptions, and replies yourself.** Autonomous agents must
+  not open issues/PRs; such PRs may be closed. **Disclose AI assistance** (tool +
+  extent). We do not accept fully or predominantly AI-generated PRs.
+- **No third-party/customer documents committed as fixtures** — build minimal
+  synthetic ones in code. Name tests by defect class, not issue/PR number.
+- **Fill in the templates.** Issues and PRs opened without filling in their
+  template are **closed automatically** (edit + reopen). Maintainers, drafts, and
+  `skip-template-check` are exempt.
+
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
@@ -339,7 +369,7 @@ git commit -s -m "feat(docx): add heading extraction"
 # Produces: Signed-off-by: Your Name <you@example.com>
 ```
 
-This is checked automatically on every pull request by the DCO CI job.
+Sign-off (`-s`) certifies your right to contribute. A strict DCO CI check is currently disabled for this repo; the **CLA check** (below) is the enforced gate on pull requests.
 
 **CLA** — non-trivial contributions are also accepted under the project's [Contributor License Agreement](CLA.md). It is a *licence, not an assignment*: you keep ownership and grant the project a broad copyright + patent licence including the right to relicense future versions. Trivial changes (typos, formatting, docs) are exempt. Once the CLA bot is enabled it records your one-click sign-off on your first PR; until then the DCO sign-off above is the operative requirement.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [".", "crates/office_oxide_cli", "crates/office_oxide_mcp"]
-exclude = ["bench_rust"]
+exclude = ["bench_rust", "fuzz"]
 
 # Clippy lint configuration shared by every workspace member and every target
 # (lib, bin, test, example, bench). Centralises the allow-list so new crates
@@ -49,6 +49,8 @@ include = [
     "/CHANGELOG.md",
     "/LICENSE-MIT",
     "/LICENSE-APACHE",
+    "/NOTICE",
+    "/TRADEMARKS.md",
     "/include/**/*",
     "/cbindgen.toml",
 ]

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,22 @@
+OfficeOxide
+Copyright (c) 2026 Yury Fedoseev and the OfficeOxide project contributors
+
+OfficeOxide is the product; "office_oxide" is the name of its packages/crate.
+
+This product is licensed under the terms of the MIT license OR the
+Apache License, Version 2.0, at your option. See LICENSE-MIT and
+LICENSE-APACHE for the full license texts.
+
+Copyright in the OfficeOxide code base is held by Yury Fedoseev and the project's
+contributors; contributions are made under the project's Contributor License
+Agreement (see CLA.md) and/or the Developer Certificate of Origin (see
+CONTRIBUTING.md), under which contributors retain ownership of their
+contributions and license them to the project.
+
+"OfficeOxide" (the product name) and "office_oxide" (the package name), together with
+any associated logo, are trademarks of Yury Fedoseev and are not covered by the
+source-code license. See TRADEMARKS.md.
+
+Portions of this software incorporate third-party open-source components; their
+respective licenses are listed in the dependency manifests (Cargo.toml /
+Cargo.lock and the per-binding package manifests).

--- a/README.md
+++ b/README.md
@@ -423,9 +423,13 @@ If it saves you a dependency, a license audit, or a weekend, consider leaving a 
 
 — Yury
 
-## License
+## License & trademark
 
-Dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. No AGPL, no GPL, no copyleft restrictions. Use freely in commercial and open-source projects.
+The **code** is dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. No AGPL, no GPL, no copyleft restrictions. Use freely in commercial and open-source projects.
+
+The **name and brand** are not covered by the code license: **"OfficeOxide"** (the product name) and **"office_oxide"** (the package name), together with any associated logo, are trademarks of Yury Fedoseev. You may say your product "uses OfficeOxide"; please don't name a different or modified product "OfficeOxide" or "office_oxide". See [TRADEMARKS.md](TRADEMARKS.md).
+
+© 2026 Yury Fedoseev and the OfficeOxide contributors. Contributions are accepted under the project's [DCO](CONTRIBUTING.md#developer-certificate-of-origin-dco) and [CLA](CLA.md); contributors retain ownership of their work.
 
 ## Contributing
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,53 @@
+# OfficeOxide Trademark Policy
+
+**"OfficeOxide"** (the product name), **"office_oxide"** (the package/crate name), and
+any associated OfficeOxide logo (the "Marks") are trademarks of Yury Fedoseev (the
+"Owner"). Common casings and near-variants used on package registries (e.g.
+`OfficeOxide`, `officeoxide`) are treated as the same Marks. The **source code** is
+open source under `MIT OR Apache-2.0`; **the Marks are not.** Owning the code
+license does not grant any right to use the Marks.
+
+This policy exists so users can always trust that something called "OfficeOxide" (or
+distributed as the `office_oxide` package) is the genuine project — the open-source
+license covers the code, this policy covers the name and brand.
+
+## You may, without asking
+- State that your product **"uses OfficeOxide"**, is **"built on OfficeOxide"**, or is
+  **"compatible with OfficeOxide"** — accurate, descriptive references (nominative
+  use). The same applies to the `office_oxide` package name.
+- Use the Marks in **blog posts, talks, tutorials, and comparisons**, as long as
+  you don't imply endorsement or official status.
+- Redistribute **unmodified** official releases under their open-source license
+  using the OfficeOxide / `office_oxide` name.
+- **Package and redistribute the software for a distribution or package manager**
+  (e.g. a Linux distro, Homebrew, conda-forge) under the `office_oxide` / OfficeOxide
+  name, including the minimal patches needed to build, package, or security-fix
+  it for that platform — provided the result stays functionally equivalent to the
+  corresponding official release and you don't imply it is a different product.
+  Larger functional forks still need a new name.
+
+## You may not, without written permission
+- Use the Marks (or a confusingly similar name/logo) as the name of **your own**
+  product, service, company, app, domain, or social/package-registry account.
+- Use the Marks in a way that suggests your product is **official, endorsed by, or
+  affiliated with** OfficeOxide when it is not.
+- Distribute a **modified** version under the OfficeOxide or `office_oxide` name (fork
+  it under a different name; you keep the code rights under the open-source
+  license, but not the name).
+- Alter the logo, or use the Marks in a way that is misleading, that falsely
+  implies endorsement or affiliation, or that is otherwise unlawful. (Accurate
+  criticism or comparison that names the Marks is fine.)
+
+## Forks and derivatives
+The open-source license lets you fork and modify the code freely. If you
+distribute a modified version, please give it a **different name** and make clear
+it is not the official OfficeOxide. You may still say it is *"a fork of OfficeOxide"* or
+*"derived from OfficeOxide"*.
+
+## Questions / permission
+For any use not clearly covered above, or to request permission, contact
+**yfedoseev@gmail.com**. We aim to be permissive for good-faith community use and
+strict only about uses that could confuse users about what the genuine project is.
+
+_This policy may be updated over time. It does not modify the terms of the
+open-source code licenses (`MIT OR Apache-2.0`)._

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+# cargo-fuzz targets for office_oxide.
+#
+# Office parsers consume fully untrusted bytes (OOXML zip/XML for Docx/Xlsx/Pptx,
+# CFB compound files for the legacy Doc/Xls/Ppt) — a prime fuzzing surface.
+# Targets must never panic on any input; malformed documents return `Err`.
+#
+# Standalone workspace (own `[workspace]`, and excluded from the root workspace)
+# so the nightly + sanitizer toolchain cargo-fuzz needs never affects the normal
+# build/test matrix.
+#
+# Run locally:  cargo +nightly fuzz run fuzz_parse -- -max_total_time=300
+[package]
+name = "office-oxide-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.office_oxide]
+path = ".."
+
+[[bin]]
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,0 +1,23 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use libfuzzer_sys::fuzz_target;
+use office_oxide::{Document, DocumentFormat};
+
+// Office documents are untrusted input: OOXML (Docx/Xlsx/Pptx) is a zip of XML,
+// the legacy formats (Doc/Xls/Ppt) are CFB compound files. Feed arbitrary bytes
+// to every format's parser — none may panic, overflow, or hang; malformed input
+// must surface as `Err`.
+fuzz_target!(|data: &[u8]| {
+    for format in [
+        DocumentFormat::Docx,
+        DocumentFormat::Xlsx,
+        DocumentFormat::Pptx,
+        DocumentFormat::Doc,
+        DocumentFormat::Xls,
+        DocumentFormat::Ppt,
+    ] {
+        let _ = Document::from_reader(Cursor::new(data.to_vec()), format);
+    }
+});


### PR DESCRIPTION
Mirrors the OpenSSF Scorecard + IP/brand hardening done on the PDFOxide project, adapted for **OfficeOxide** (packages `office_oxide`; MIT OR Apache-2.0; 2026). The governance docs incorporate the same independent review a governance/IP reviewer gave the PDFOxide versions.

## OpenSSF Scorecard
- **Token-Permissions** — `permissions: contents: read` added to `python.yml` (the only workflow lacking a block).
- **Fuzzing** (0→10) — in-repo cargo-fuzz target hitting `Document::from_reader` across all six formats (OOXML zip/XML for Docx/Xlsx/Pptx + legacy CFB for Doc/Xls/Ppt) — a genuine untrusted-input surface. Standalone workspace, excluded from the root workspace so it never touches the normal build/test matrix (verified: root members unchanged).

## IP / brand governance
Preserves the relicense lever + acquisition value; brand is a fully-ownable asset independent of the code license.
- **`CLA.md`** — Apache-ICLA-derived **licence, not assignment**: broad sub-licensable copyright **+ patent** grant, **assignable to successors** (acquisition value), moral-rights waiver, entire-agreement/misc, governing-law placeholder.
- **`TRADEMARKS.md`** — OfficeOxide/office_oxide marks, nominative-use allowances, **distro/packager carve-out**, casing-variant coverage.
- **`NOTICE`** — copyright consolidation; added to the crate `include`.
- **CONTRIBUTING** — replaces "there is no CLA" with the CLA reference and reconciles the "no additional terms" wording with the CLA's broader grant (the one real contradiction the review flagged).
- **README** — License & Trademark section + © 2026 / ™ line.

## ⚠️ Before "live" (you / counsel — not code)
Governing law/venue in the CLA, trademark registration (esp. the descriptive `office_oxide`), and **enabling a CLA bot before substantial contributions** so the clean relicense right + patent grant attach from day one. I'm not a lawyer — this is standard-template scaffolding reviewed by an agent, not legal advice.

https://claude.ai/code/session_01QXMiKnxkmFs3tCQNz1vMc5