### PR TITLE
fix(ppt): resolve slide text through the PPT97 persist directory

### DIFF
--- a/src/ppt/document.rs
+++ b/src/ppt/document.rs
@@ -34,7 +34,8 @@ impl PptDocument {
             },
         };
 
-        let slides = extract_slides_text(&stream);
+        let current_user = cfb.open_stream("Current User").ok();
+        let slides = extract_slides_text(&stream, current_user.as_deref());
 
         // Extract images from Pictures stream (if present).
         let images = match cfb.open_stream("Pictures") {

--- a/src/ppt/mod.rs
+++ b/src/ppt/mod.rs
@@ -12,6 +12,7 @@
 mod document;
 mod error;
 pub mod images;
+mod persist;
 mod records;
 mod text;
 

--- a/src/ppt/persist.rs
+++ b/src/ppt/persist.rs
@@ -1,0 +1,333 @@
+//! Persist object directory resolution for legacy PPT97 binary files.
+//!
+//! PowerPoint 97 uses incremental ("fast") saves: each save appends new or
+//! changed top-level records to the end of the "PowerPoint Document" stream
+//! and writes a fresh `UserEditAtom` + `PersistDirectoryAtom` recording where
+//! the *current* copy of every persist object now lives. Older, superseded
+//! copies of records (e.g. a `Slide` container from before an edit) are left
+//! behind in the stream — nothing compacts them away.
+//!
+//! A naive sequential scan of the stream from front to back therefore cannot
+//! tell current content from stale, orphaned leftovers: whichever copy
+//! happens to come first wins. Locating the *current* content for a given
+//! slide requires resolving its `persistIdRef` through this directory, built
+//! by walking `CurrentUserAtom.offsetToCurrentEdit` → `UserEditAtom` chain
+//! (via `offsetLastEdit`) → merged `PersistDirectoryAtom` entries, per
+//! [MS-PPT] 2.1.2.
+
+use std::collections::{HashMap, HashSet};
+
+use super::records::{
+    RT_CURRENT_USER_ATOM, RT_PERSIST_DIRECTORY_ATOM, RT_USER_EDIT_ATOM, RecordHeader, RecordIter,
+};
+
+/// Guards against a corrupted or cyclic `offsetLastEdit` chain.
+const MAX_EDIT_CHAIN_LEN: usize = 4096;
+
+/// Resolves a persist object identifier to its current byte offset within the
+/// "PowerPoint Document" stream.
+#[derive(Debug, Default, Clone)]
+pub struct PersistDirectory {
+    offsets: HashMap<u32, u32>,
+    /// Persist ID of the current `DocumentContainer` (`UserEditAtom.docPersistIdRef`).
+    pub doc_persist_id: u32,
+}
+
+impl PersistDirectory {
+    /// Byte offset of the persist object with the given ID, if known.
+    pub fn resolve(&self, persist_id: u32) -> Option<usize> {
+        self.offsets.get(&persist_id).map(|&o| o as usize)
+    }
+}
+
+/// Build the persist object directory for `stream` (the raw "PowerPoint
+/// Document" bytes).
+///
+/// `current_user` is the raw "Current User" stream, if present; its
+/// `offsetToCurrentEdit` field is the normal, spec-correct way to find the
+/// most recent `UserEditAtom`. When that stream is absent, or its offset
+/// doesn't land on a valid `UserEditAtom`, falls back to a bounded top-level
+/// scan of `stream` for the highest-offset `UserEditAtom` — every save
+/// appends a fresh one at the end, so the highest offset is always the most
+/// recent edit regardless of what the `Current User` stream says.
+///
+/// Returns `None` if no `UserEditAtom` can be found at all (e.g. a minimal
+/// hand-built stream in a test) — callers should fall back to a different
+/// extraction strategy in that case.
+pub fn build(stream: &[u8], current_user: Option<&[u8]>) -> Option<PersistDirectory> {
+    let start = current_user
+        .and_then(offset_to_current_edit)
+        .filter(|&off| user_edit_atom_at(stream, off).is_some())
+        .or_else(|| find_latest_user_edit_atom(stream))?;
+
+    let mut dir = PersistDirectory::default();
+    let mut offset = Some(start);
+    let mut seen = HashSet::new();
+    let mut doc_persist_id = None;
+
+    for _ in 0..MAX_EDIT_CHAIN_LEN {
+        let Some(off) = offset else { break };
+        if !seen.insert(off) {
+            break; // cyclic offsetLastEdit chain
+        }
+
+        let Some(edit) = user_edit_atom_at(stream, off) else {
+            break;
+        };
+        if doc_persist_id.is_none() {
+            doc_persist_id = Some(edit.doc_persist_id_ref);
+        }
+
+        if let Some(entries) = persist_directory_entries_at(stream, edit.offset_persist_directory) {
+            // Visiting newest-edit-first: only fill in IDs not already known,
+            // so an older edit's entry never overwrites a newer one.
+            for (id, off) in entries {
+                dir.offsets.entry(id).or_insert(off);
+            }
+        }
+
+        offset = if edit.offset_last_edit == 0 {
+            None
+        } else {
+            Some(edit.offset_last_edit as usize)
+        };
+    }
+
+    dir.doc_persist_id = doc_persist_id.unwrap_or(1);
+    Some(dir)
+}
+
+struct UserEditAtom {
+    offset_last_edit: u32,
+    offset_persist_directory: u32,
+    doc_persist_id_ref: u32,
+}
+
+/// Parse a `UserEditAtom` ([MS-PPT] 2.3.3) at an absolute offset in `stream`.
+///
+/// Body layout: `lastSlideIdRef`(4)@0, packed version fields(4)@4,
+/// `offsetLastEdit`(4)@8, `offsetPersistDirectory`(4)@12,
+/// `docPersistIdRef`(4)@16, `persistIdSeed`(4)@20, `lastView`+`unused`(4)@24.
+fn user_edit_atom_at(stream: &[u8], offset: usize) -> Option<UserEditAtom> {
+    let header_bytes = stream.get(offset..offset + 8)?;
+    let header = RecordHeader::parse(header_bytes).ok()?;
+    if header.rec_type != RT_USER_EDIT_ATOM || header.is_container() {
+        return None;
+    }
+    let body_start = offset + 8;
+    let body_end = body_start
+        .saturating_add(header.rec_len as usize)
+        .min(stream.len());
+    let body = stream.get(body_start..body_end)?;
+    if body.len() < 20 {
+        return None;
+    }
+    Some(UserEditAtom {
+        offset_last_edit: u32::from_le_bytes([body[8], body[9], body[10], body[11]]),
+        offset_persist_directory: u32::from_le_bytes([body[12], body[13], body[14], body[15]]),
+        doc_persist_id_ref: u32::from_le_bytes([body[16], body[17], body[18], body[19]]),
+    })
+}
+
+/// Parse a `CurrentUserAtom` ([MS-PPT] 2.3.2) `offsetToCurrentEdit` field
+/// (body offset 8, 4 bytes) from the raw "Current User" stream.
+fn offset_to_current_edit(current_user: &[u8]) -> Option<usize> {
+    let header = RecordHeader::parse(current_user.get(0..8)?).ok()?;
+    if header.rec_type != RT_CURRENT_USER_ATOM || header.is_container() {
+        return None;
+    }
+    let body = current_user.get(8..)?;
+    let field = body.get(8..12)?;
+    Some(u32::from_le_bytes([field[0], field[1], field[2], field[3]]) as usize)
+}
+
+/// Parse a `PersistDirectoryAtom` ([MS-PPT] 2.3.4/2.3.5) at an absolute
+/// offset in `stream`, returning `(persistId, streamOffset)` pairs.
+///
+/// Each `PersistDirectoryEntry` is a 4-byte header (`persistId` in the low 20
+/// bits, `cPersist` count in the high 12 bits) followed by `cPersist` 4-byte
+/// stream offsets for sequential persist IDs starting at `persistId`.
+fn persist_directory_entries_at(stream: &[u8], offset: u32) -> Option<Vec<(u32, u32)>> {
+    let offset = offset as usize;
+    let header_bytes = stream.get(offset..offset + 8)?;
+    let header = RecordHeader::parse(header_bytes).ok()?;
+    if header.rec_type != RT_PERSIST_DIRECTORY_ATOM || header.is_container() {
+        return None;
+    }
+    let body_start = offset + 8;
+    let body_end = body_start
+        .saturating_add(header.rec_len as usize)
+        .min(stream.len());
+    let body = stream.get(body_start..body_end)?;
+
+    let mut entries = Vec::new();
+    let mut pos = 0usize;
+    while pos + 4 <= body.len() {
+        let word = u32::from_le_bytes([body[pos], body[pos + 1], body[pos + 2], body[pos + 3]]);
+        let persist_id = word & 0x000F_FFFF;
+        let c_persist = (word >> 20) as usize;
+        pos += 4;
+
+        for i in 0..c_persist {
+            let Some(chunk) = body.get(pos..pos + 4) else {
+                break;
+            };
+            let off = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            entries.push((persist_id.wrapping_add(i as u32), off));
+            pos += 4;
+        }
+    }
+    Some(entries)
+}
+
+/// Bounded top-level scan for the highest-offset `UserEditAtom` in `stream`.
+///
+/// `UserEditAtom`s only ever appear at the top level of the stream (never
+/// nested inside another container), so a single-level, non-recursive walk
+/// is sufficient — and safe even when some unrelated top-level record has a
+/// corrupted/oversized length, since `RecordIter` bounds each record by its
+/// own declared length rather than by successfully parsing its contents.
+fn find_latest_user_edit_atom(stream: &[u8]) -> Option<usize> {
+    let mut latest = None;
+    for rec in RecordIter::new(stream) {
+        let Ok(rec) = rec else { break };
+        if rec.header.rec_type == RT_USER_EDIT_ATOM && !rec.header.is_container() {
+            latest = Some(rec.offset);
+        }
+    }
+    latest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_atom(rec_type: u16, instance: u16, data: &[u8]) -> Vec<u8> {
+        let ver_instance: u16 = instance << 4;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&ver_instance.to_le_bytes());
+        buf.extend_from_slice(&rec_type.to_le_bytes());
+        buf.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(data);
+        buf
+    }
+
+    fn user_edit_atom_bytes(
+        offset_last_edit: u32,
+        offset_persist_directory: u32,
+        doc_persist_id_ref: u32,
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0u32.to_le_bytes()); // lastSlideIdRef
+        body.extend_from_slice(&0u32.to_le_bytes()); // version/minor/major
+        body.extend_from_slice(&offset_last_edit.to_le_bytes());
+        body.extend_from_slice(&offset_persist_directory.to_le_bytes());
+        body.extend_from_slice(&doc_persist_id_ref.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // persistIdSeed
+        body.extend_from_slice(&0u32.to_le_bytes()); // lastView + unused
+        make_atom(RT_USER_EDIT_ATOM, 0, &body)
+    }
+
+    fn persist_directory_bytes(entries: &[(u32, u32)]) -> Vec<u8> {
+        assert!(!entries.is_empty());
+        let persist_id = entries[0].0;
+        let c_persist = entries.len() as u32;
+        let header = persist_id | (c_persist << 20);
+        let mut body = header.to_le_bytes().to_vec();
+        for (_, off) in entries {
+            body.extend_from_slice(&off.to_le_bytes());
+        }
+        make_atom(RT_PERSIST_DIRECTORY_ATOM, 0, &body)
+    }
+
+    fn current_user_bytes(offset_to_current_edit: u32) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0u32.to_le_bytes()); // size
+        body.extend_from_slice(&0u32.to_le_bytes()); // headerToken
+        body.extend_from_slice(&offset_to_current_edit.to_le_bytes());
+        body.extend_from_slice(&0u16.to_le_bytes()); // lenUserName
+        body.extend_from_slice(&0u16.to_le_bytes()); // docFileVersion
+        body.push(0); // majorVersion
+        body.push(0); // minorVersion
+        body.extend_from_slice(&0u16.to_le_bytes()); // unused
+        make_atom(RT_CURRENT_USER_ATOM, 0, &body)
+    }
+
+    #[test]
+    fn persist_directory_entry_bit_layout() {
+        // persistId=5 (low 20 bits), cPersist=3 (high 12 bits), 3 offsets.
+        let pd = persist_directory_bytes(&[(5, 100), (6, 200), (7, 300)]);
+        let mut stream = vec![0u8; 16];
+        stream.extend(pd);
+        let entries = persist_directory_entries_at(&stream, 16).unwrap();
+        assert_eq!(entries, vec![(5, 100), (6, 200), (7, 300)]);
+    }
+
+    #[test]
+    fn resolves_current_edit_via_current_user_stream() {
+        let mut stream = Vec::new();
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, 0), (2, 42)]));
+        let edit_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+
+        let current_user = current_user_bytes(edit_offset);
+        let dir = build(&stream, Some(&current_user)).unwrap();
+
+        assert_eq!(dir.doc_persist_id, 1);
+        assert_eq!(dir.resolve(1), Some(0));
+        assert_eq!(dir.resolve(2), Some(42));
+    }
+
+    #[test]
+    fn falls_back_to_brute_force_scan_without_current_user_stream() {
+        let mut stream = Vec::new();
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, 0), (2, 42)]));
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+
+        let dir = build(&stream, None).unwrap();
+        assert_eq!(dir.resolve(2), Some(42));
+    }
+
+    #[test]
+    fn newer_edit_entry_wins_over_older_edit_for_same_persist_id() {
+        let mut stream = Vec::new();
+
+        // Oldest edit: persist id 2 -> stale offset 10.
+        let pd1_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(2, 10)]));
+        let edit1_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd1_offset, 1));
+
+        // Newest edit: persist id 2 -> current offset 99, chained back to edit1.
+        let pd2_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(2, 99)]));
+        let edit2_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(edit1_offset, pd2_offset, 1));
+
+        let current_user = current_user_bytes(edit2_offset);
+        let dir = build(&stream, Some(&current_user)).unwrap();
+        assert_eq!(dir.resolve(2), Some(99), "newest edit's directory entry must win");
+    }
+
+    #[test]
+    fn cyclic_offset_last_edit_does_not_hang() {
+        let mut stream = Vec::new();
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, 0)]));
+        let edit_offset = stream.len() as u32;
+        // offsetLastEdit points at itself.
+        stream.extend(user_edit_atom_bytes(edit_offset, pd_offset, 1));
+
+        let current_user = current_user_bytes(edit_offset);
+        let dir = build(&stream, Some(&current_user)).unwrap();
+        assert_eq!(dir.resolve(1), Some(0));
+    }
+
+    #[test]
+    fn no_user_edit_atom_returns_none() {
+        assert!(build(&[], None).is_none());
+        assert!(build(b"not a ppt stream at all", None).is_none());
+    }
+}

--- a/src/ppt/records.rs
+++ b/src/ppt/records.rs
@@ -19,6 +19,11 @@ pub const RT_SLIDE_BASE: u16 = 0x03EC;
 pub const RT_NOTES: u16 = 0x03F0;
 pub const RT_SLIDE_LIST_WITH_TEXT: u16 = 0x0FF0;
 pub const RT_TEXT_HEADER: u16 = 0x0F9F;
+/// OutlineTextRefAtom ([MS-PPT] 2.4.15.6) — a shape's text stored *by
+/// reference* as a zero-based index into the TextHeaderAtom sequence that
+/// follows its slide's SlidePersistAtom in SlideListWithTextContainer,
+/// instead of embedded directly in the shape.
+pub const RT_OUTLINE_TEXT_REF_ATOM: u16 = 0x0F9E;
 pub const RT_TEXT_CHARS: u16 = 0x0FA0;
 pub const RT_TEXT_BYTES: u16 = 0x0FA8;
 pub const RT_SLIDE_PERSIST_ATOM: u16 = 0x03F3;

--- a/src/ppt/records.rs
+++ b/src/ppt/records.rs
@@ -23,14 +23,22 @@ pub const RT_TEXT_CHARS: u16 = 0x0FA0;
 pub const RT_TEXT_BYTES: u16 = 0x0FA8;
 pub const RT_SLIDE_PERSIST_ATOM: u16 = 0x03F3;
 pub const RT_USER_EDIT_ATOM: u16 = 0x0FF5;
-pub const RT_PERSIST_DIR: u16 = 0x1772;
-pub const RT_PERSIST_DIR_ENTRY: u16 = 0x1772;
+/// PersistDirectoryAtom ([MS-PPT] 2.3.4).
+pub const RT_PERSIST_DIRECTORY_ATOM: u16 = 0x1772;
 pub const RT_CURRENT_USER_ATOM: u16 = 0x0FF6;
 pub const RT_HEADER_FOOTER: u16 = 0x0FDA;
 pub const RT_TEXT_SPECIAL_INFO: u16 = 0x0FAA;
 pub const RT_TEXT_RULER: u16 = 0x0FA2;
 pub const RT_STYLE_TEXT_PROP: u16 = 0x0FA1;
 pub const RT_CSTRING: u16 = 0x0FBA;
+
+// ── SlideListWithText `rh.recInstance` discriminants ([MS-PPT] 2.4.14) ──
+/// `rh.recInstance` value identifying a `SlideListWithTextContainer` (real slides).
+pub const SLWT_SLIDES: u16 = 0;
+/// `rh.recInstance` value identifying a `MasterListWithTextContainer`.
+pub const SLWT_MASTERS: u16 = 1;
+/// `rh.recInstance` value identifying a `NotesListWithTextContainer`.
+pub const SLWT_NOTES: u16 = 2;
 
 /// A parsed PPT record header.
 #[derive(Debug, Clone, Copy)]
@@ -72,7 +80,21 @@ pub struct PptRecord {
     pub offset: usize,
 }
 
-/// Iterate over records in a byte stream (flat, non-recursive).
+/// Iterate over the immediate children of one record region (single level,
+/// non-recursive).
+///
+/// Each yielded record's `data` is bounded strictly by that record's own
+/// declared `rec_len`, clamped to whatever bytes actually remain in the slice
+/// passed to [`RecordIter::new`] — never by descending into (or trusting the
+/// declared lengths of) anything nested further down. For a container record,
+/// `data` is its bounded *children* region; recurse by constructing a new
+/// `RecordIter::new(&container_record.data)`.
+///
+/// This bounding is what keeps a corrupted or maliciously oversized `rec_len`
+/// on one record from swallowing bytes that belong to its siblings, or to
+/// anything outside its own enclosing container: skipping to the next sibling
+/// only ever relies on the current record's own header, never on correctly
+/// parsing what's inside it.
 pub struct RecordIter<'a> {
     data: &'a [u8],
     pos: usize,
@@ -97,34 +119,19 @@ impl<'a> Iterator for RecordIter<'a> {
             Err(e) => return Some(Err(e)),
         };
 
-        let data_start = self.pos + 8;
-        let data_end = data_start + header.rec_len as usize;
         let record_offset = self.pos;
+        let data_start = (self.pos + 8).min(self.data.len());
+        // Clamp to *this* slice's own end — never trust rec_len past what's
+        // actually here, whether the record is an atom or a container.
+        let data_end = data_start
+            .saturating_add(header.rec_len as usize)
+            .min(self.data.len());
 
-        if header.is_container() {
-            // For containers, advance past header only — children follow.
-            self.pos = data_start;
-        } else {
-            // For atoms, skip over the data.
-            if data_end > self.data.len() {
-                // Truncated record — skip to end.
-                self.pos = self.data.len();
-            } else {
-                self.pos = data_end;
-            }
-        }
-
-        let data = if header.is_container() {
-            Vec::new()
-        } else if data_end <= self.data.len() {
-            self.data[data_start..data_end].to_vec()
-        } else {
-            self.data[data_start..].to_vec()
-        };
+        self.pos = data_end;
 
         Some(Ok(PptRecord {
             header,
-            data,
+            data: self.data[data_start..data_end].to_vec(),
             offset: record_offset,
         }))
     }
@@ -186,22 +193,31 @@ mod tests {
     }
 
     #[test]
-    fn iterate_container_with_children() {
+    fn container_children_are_bounded_not_flattened() {
         let child1 = make_atom(RT_TEXT_HEADER, 0, &[0x00, 0x00, 0x00, 0x00]);
         let child2 = make_atom(RT_TEXT_CHARS, 0, &[0x41, 0x00]);
         let mut children = child1.clone();
         children.extend(&child2);
         let container = make_container(RT_SLIDE_LIST_WITH_TEXT, 0, &children);
 
+        // A single-level iteration over the container yields the container
+        // itself, not its descendants — it must not implicitly flatten.
         let records: Vec<_> = RecordIter::new(&container)
             .collect::<std::result::Result<_, _>>()
             .unwrap();
-        // Container header + 2 children = 3 records.
-        assert_eq!(records.len(), 3);
+        assert_eq!(records.len(), 1);
         assert_eq!(records[0].header.rec_type, RT_SLIDE_LIST_WITH_TEXT);
         assert!(records[0].header.is_container());
-        assert_eq!(records[1].header.rec_type, RT_TEXT_HEADER);
-        assert_eq!(records[2].header.rec_type, RT_TEXT_CHARS);
+        assert_eq!(records[0].data, children);
+
+        // Recursing explicitly into the container's own bounded child region
+        // reaches both children.
+        let nested: Vec<_> = RecordIter::new(&records[0].data)
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(nested.len(), 2);
+        assert_eq!(nested[0].header.rec_type, RT_TEXT_HEADER);
+        assert_eq!(nested[1].header.rec_type, RT_TEXT_CHARS);
     }
 
     #[test]
@@ -210,5 +226,45 @@ mod tests {
             .collect::<std::result::Result<_, _>>()
             .unwrap();
         assert!(records.is_empty());
+    }
+
+    /// A single record with a corrupted/oversized declared length, nested
+    /// inside a container, must not swallow bytes belonging to a sibling
+    /// record *outside* that container. Skipping to the next sibling must
+    /// rely only on the container's own header length, never on successfully
+    /// parsing (or bounding) what's inside it.
+    #[test]
+    fn corrupt_nested_record_length_does_not_swallow_top_level_siblings() {
+        // A child atom that declares a wildly oversized length with no data
+        // behind it (simulating real-world corrupted/non-conformant files).
+        let mut corrupt_child = Vec::new();
+        corrupt_child.extend_from_slice(&0u16.to_le_bytes()); // ver=0 (atom), instance=0
+        corrupt_child.extend_from_slice(&RT_TEXT_CHARS.to_le_bytes());
+        corrupt_child.extend_from_slice(&1_000_000u32.to_le_bytes()); // bogus length
+
+        let outer = make_container(RT_SLIDE, 0, &corrupt_child);
+
+        let mut stream = outer;
+        stream.extend(make_atom(RT_TEXT_BYTES, 0, b"sibling text"));
+
+        let records: Vec<_> = RecordIter::new(&stream)
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            records.len(),
+            2,
+            "corrupt length nested inside the container must not swallow the top-level sibling after it"
+        );
+        assert_eq!(records[0].header.rec_type, RT_SLIDE);
+        assert_eq!(records[1].header.rec_type, RT_TEXT_BYTES);
+        assert_eq!(records[1].data, b"sibling text");
+
+        // Descending into the corrupt container's own children must clamp to
+        // the bytes actually available, not panic or run past the container.
+        let inner: Vec<_> = RecordIter::new(&records[0].data)
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(inner.len(), 1);
+        assert!(inner[0].data.len() < 1_000_000);
     }
 }

--- a/src/ppt/text.rs
+++ b/src/ppt/text.rs
@@ -68,7 +68,13 @@ pub struct TextRun {
 pub fn extract_slides_text(stream: &[u8], current_user: Option<&[u8]>) -> Vec<SlideText> {
     if let Some(dir) = persist::build(stream, current_user) {
         if let Some(slides) = extract_slides_via_persist(stream, &dir) {
-            if !slides.is_empty() {
+            // A resolved-but-entirely-textless result is ambiguous: it's the
+            // correct answer for a genuinely text-free deck (image-only
+            // slides), but it's also what a corrupted persist chain that
+            // resolved to the wrong offsets looks like. Fall through to the
+            // weaker heuristics below rather than committing to it — if they
+            // also come up empty, this was the right answer all along.
+            if !slides.is_empty() && slides.iter().any(|s| !s.text_runs.is_empty()) {
                 return slides;
             }
         }
@@ -84,7 +90,7 @@ pub fn extract_slides_text(stream: &[u8], current_user: Option<&[u8]>) -> Vec<Sl
     // Last resort: no resolvable structure at all — dump whatever text atoms
     // exist anywhere in the stream as a single slide.
     let mut runs = Vec::new();
-    extract_shape_text(stream, 0, &mut runs);
+    extract_shape_text(stream, 0, &[], &mut runs);
     if runs.is_empty() {
         Vec::new()
     } else {
@@ -95,6 +101,14 @@ pub fn extract_slides_text(stream: &[u8], current_user: Option<&[u8]>) -> Vec<Sl
 /// Resolve the current "Slides" list through the persist directory and
 /// extract each slide's shape text from its resolved `Slide` container.
 ///
+/// Also collects each slide's own outline-text sequence — the
+/// `TextHeaderAtom`/`TextCharsAtom`/`TextBytesAtom` runs that directly follow
+/// its `SlidePersistAtom` in `SlideListWithTextContainer` — because many
+/// placeholder shapes don't embed their text directly at all: they hold only
+/// an `OutlineTextRefAtom`, an index into that same per-slide sequence
+/// ([MS-PPT] 2.4.15.6). Resolving text purely from the `Slide` container's own
+/// records, without this table, silently drops that text.
+///
 /// Returns `None` if the `DocumentContainer` or its slide list can't be
 /// resolved at all (directory present but unusable); returns `Some(vec![])`
 /// if the slide list resolves but is empty.
@@ -104,39 +118,94 @@ fn extract_slides_via_persist(stream: &[u8], dir: &PersistDirectory) -> Option<V
     let slide_list = find_child(&doc_children, RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES)?;
 
     let mut slides = Vec::new();
+    let mut current_persist_id: Option<u32> = None;
+    let mut outline_texts: Vec<TextRun> = Vec::new();
+    let mut current_type = TextType::Other;
+
     for rec in RecordIter::new(&slide_list) {
         let Ok(rec) = rec else { break };
-        if rec.header.rec_type != RT_SLIDE_PERSIST_ATOM || rec.data.len() < 4 {
-            continue;
+        match rec.header.rec_type {
+            RT_SLIDE_PERSIST_ATOM if rec.data.len() >= 4 => {
+                if let Some(persist_id_ref) = current_persist_id.take() {
+                    slides.push(resolve_slide(stream, dir, persist_id_ref, &outline_texts));
+                }
+                current_persist_id =
+                    Some(u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]));
+                outline_texts.clear();
+                current_type = TextType::Other;
+            },
+            RT_TEXT_HEADER if rec.data.len() >= 4 => {
+                let t = u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
+                current_type = TextType::from_u32(t);
+            },
+            RT_TEXT_CHARS => {
+                // Positional index into this list is meaningful (it's what
+                // OutlineTextRefAtom references) — an empty run still
+                // occupies a slot and must not be skipped here.
+                outline_texts.push(TextRun {
+                    text_type: current_type,
+                    text: decode_utf16le(&rec.data),
+                });
+            },
+            RT_TEXT_BYTES => {
+                outline_texts.push(TextRun {
+                    text_type: current_type,
+                    text: rec.data.iter().map(|&b| b as char).collect(),
+                });
+            },
+            _ => {},
         }
-        let persist_id_ref =
-            u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
-
-        let mut text_runs = Vec::new();
-        if let Some(offset) = dir.resolve(persist_id_ref) {
-            if let Some(children) = bounded_container_children(stream, offset, RT_SLIDE) {
-                extract_shape_text(&children, 0, &mut text_runs);
-            }
-        }
-
-        // Every persist-directory-resolved slide is kept regardless of
-        // whether text was found — an image-only slide is still a slide,
-        // and the presentation's true slide count matters for numbering.
-        slides.push(SlideText { text_runs });
+    }
+    if let Some(persist_id_ref) = current_persist_id.take() {
+        slides.push(resolve_slide(stream, dir, persist_id_ref, &outline_texts));
     }
 
     Some(slides)
 }
 
-/// Recursively collect `TextHeaderAtom` + `TextCharsAtom`/`TextBytesAtom`
-/// pairs from a bounded record region (a resolved `Slide`/`Notes`/`MainMaster`
-/// container's own children), in document order.
+/// Resolve one slide's shape text: locate its `Slide` container via the
+/// persist directory and walk its shape tree, resolving any
+/// `OutlineTextRefAtom` references against `outline_texts`.
+///
+/// Every persist-directory-resolved slide is kept regardless of whether text
+/// was found — an image-only slide is still a slide, and the presentation's
+/// true slide count matters for numbering.
+fn resolve_slide(
+    stream: &[u8],
+    dir: &PersistDirectory,
+    persist_id_ref: u32,
+    outline_texts: &[TextRun],
+) -> SlideText {
+    let mut text_runs = Vec::new();
+    if let Some(offset) = dir.resolve(persist_id_ref) {
+        if let Some(children) = bounded_container_children(stream, offset, RT_SLIDE) {
+            extract_shape_text(&children, 0, outline_texts, &mut text_runs);
+        }
+    }
+    SlideText { text_runs }
+}
+
+/// Recursively collect a shape tree's text, in document order, from a bounded
+/// record region (a resolved `Slide`/`Notes`/`MainMaster` container's own
+/// children).
+///
+/// Text comes from two places: `TextHeaderAtom` + `TextCharsAtom`/
+/// `TextBytesAtom` pairs embedded directly in a shape, or an
+/// `OutlineTextRefAtom` resolved against `outline_texts` (see
+/// [`extract_slides_via_persist`]) for shapes that store their text there
+/// instead. Pass `&[]` when no outline-text table applies (e.g. the
+/// no-persist-directory fallback).
 ///
 /// Bounded per [`RecordIter`]'s container semantics: a corrupted/oversized
 /// length on one shape can, at worst, truncate the remaining shapes within
 /// that *same* container — it can never affect anything outside the region
 /// this function was called with.
-fn extract_shape_text(data: &[u8], depth: usize, out: &mut Vec<TextRun>) {
+fn extract_shape_text(
+    data: &[u8],
+    depth: usize,
+    outline_texts: &[TextRun],
+    out: &mut Vec<TextRun>,
+) {
     if depth > MAX_SHAPE_DEPTH {
         return;
     }
@@ -167,8 +236,19 @@ fn extract_shape_text(data: &[u8], depth: usize, out: &mut Vec<TextRun>) {
                     });
                 }
             },
+            RT_OUTLINE_TEXT_REF_ATOM if rec.data.len() >= 4 => {
+                let index =
+                    i32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
+                if index >= 0 {
+                    if let Some(run) = outline_texts.get(index as usize) {
+                        if !run.text.is_empty() {
+                            out.push(run.clone());
+                        }
+                    }
+                }
+            },
             _ if rec.header.is_container() => {
-                extract_shape_text(&rec.data, depth + 1, out);
+                extract_shape_text(&rec.data, depth + 1, outline_texts, out);
             },
             _ => {},
         }
@@ -177,12 +257,11 @@ fn extract_shape_text(data: &[u8], depth: usize, out: &mut Vec<TextRun>) {
 
 /// Fallback used only when the persist directory can't be resolved at all:
 /// derive slide boundaries from a `SlideListWithText`'s own inline text cache
-/// — a `SlidePersistAtom` optionally followed directly by up to 8
-/// `TextHeaderAtom` + `TextCharsAtom`/`TextBytesAtom` pairs ([MS-PPT]
-/// 2.4.14.3). This cache is optional, capped, and not authoritative (the
-/// resolved `Slide` container is the source of truth) — real-world files
-/// routinely leave it empty, which is why this is a fallback and not the
-/// primary path.
+/// — a `SlidePersistAtom` followed directly by `TextHeaderAtom` +
+/// `TextCharsAtom`/`TextBytesAtom` pairs ([MS-PPT] 2.4.14.3). The resolved
+/// `Slide` container (primary path above) additionally resolves
+/// `OutlineTextRefAtom` indirection against this same sequence; this fallback
+/// is only reached when persist resolution isn't available at all.
 fn extract_slides_from_slide_list_cache(slide_list: &[u8]) -> Vec<SlideText> {
     let mut slides: Vec<SlideText> = Vec::new();
     let mut current: Option<SlideText> = None;
@@ -334,7 +413,7 @@ mod tests {
         // "Hi" in UTF-16LE
         stream.extend(make_atom(RT_TEXT_CHARS, 0, &[0x48, 0x00, 0x69, 0x00]));
         let mut runs = Vec::new();
-        extract_shape_text(&stream, 0, &mut runs);
+        extract_shape_text(&stream, 0, &[], &mut runs);
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].text, "Hi");
         assert_eq!(runs[0].text_type, TextType::Title);
@@ -345,7 +424,7 @@ mod tests {
         let mut stream = make_atom(RT_TEXT_HEADER, 0, &1u32.to_le_bytes()); // Body
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Hello World"));
         let mut runs = Vec::new();
-        extract_shape_text(&stream, 0, &mut runs);
+        extract_shape_text(&stream, 0, &[], &mut runs);
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].text, "Hello World");
         assert_eq!(runs[0].text_type, TextType::Body);
@@ -358,7 +437,7 @@ mod tests {
         stream.extend(make_atom(RT_TEXT_HEADER, 0, &1u32.to_le_bytes()));
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Body text"));
         let mut runs = Vec::new();
-        extract_shape_text(&stream, 0, &mut runs);
+        extract_shape_text(&stream, 0, &[], &mut runs);
         assert_eq!(runs.len(), 2);
         assert_eq!(runs[0].text, "Title");
         assert_eq!(runs[1].text, "Body text");
@@ -375,7 +454,7 @@ mod tests {
         let shape = make_container(0xF004, 0, &textbox); // shape container
 
         let mut runs = Vec::new();
-        extract_shape_text(&shape, 0, &mut runs);
+        extract_shape_text(&shape, 0, &[], &mut runs);
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].text, "Nested");
     }
@@ -592,5 +671,99 @@ mod tests {
             slides[0].text_runs[0].text, "REAL SLIDE TEXT",
             "a corrupted record's length must not prevent later real content from being found"
         );
+    }
+
+    #[test]
+    fn outline_text_ref_atom_resolves_indexed_placeholder_text() {
+        // A shape whose ClientTextbox holds only an OutlineTextRefAtom
+        // (index 1) instead of embedding its own TextHeaderAtom/TextChars —
+        // the placeholder-text-by-reference pattern real PPT97 title/body
+        // placeholders commonly use ([MS-PPT] 2.4.15.6).
+        let outline_texts = vec![
+            TextRun {
+                text_type: TextType::Title,
+                text: "first".into(),
+            },
+            TextRun {
+                text_type: TextType::Body,
+                text: "second".into(),
+            },
+        ];
+
+        let mut index_bytes = Vec::new();
+        index_bytes.extend_from_slice(&1i32.to_le_bytes());
+        let outline_ref = make_atom(RT_OUTLINE_TEXT_REF_ATOM, 0, &index_bytes);
+        let textbox = make_container(0xF00D, 0, &outline_ref);
+        let shape = make_container(0xF004, 0, &textbox);
+
+        let mut runs = Vec::new();
+        extract_shape_text(&shape, 0, &outline_texts, &mut runs);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "second");
+        assert_eq!(runs[0].text_type, TextType::Body);
+    }
+
+    #[test]
+    fn persist_resolution_follows_outline_text_ref_atom() {
+        // A Slide container whose only shape holds an OutlineTextRefAtom, with
+        // the actual text living in the SlideListWithText's per-slide outline
+        // cache rather than embedded in the shape itself.
+        let mut stream = Vec::new();
+
+        let doc_offset = stream.len() as u32;
+        let mut slide_list_children = slide_persist_atom_bytes(2, 256);
+        slide_list_children.extend(make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes()));
+        slide_list_children.extend(make_atom(RT_TEXT_BYTES, 0, b"OUTLINE-REFERENCED TEXT"));
+        let slide_list = make_container(RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, &slide_list_children);
+        stream.extend(make_container(RT_DOCUMENT, 0, &slide_list));
+
+        let real_slide_offset = stream.len() as u32;
+        let mut index_bytes = Vec::new();
+        index_bytes.extend_from_slice(&0i32.to_le_bytes());
+        let outline_ref = make_atom(RT_OUTLINE_TEXT_REF_ATOM, 0, &index_bytes);
+        let textbox = make_container(0xF00D, 0, &outline_ref);
+        let shape = make_container(0xF004, 0, &textbox);
+        stream.extend(make_container(RT_SLIDE, 0, &shape));
+
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, doc_offset), (2, real_slide_offset)]));
+        let edit_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+        let current_user = current_user_bytes(edit_offset);
+
+        let slides = extract_slides_text(&stream, Some(&current_user));
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].text_runs[0].text, "OUTLINE-REFERENCED TEXT");
+    }
+
+    #[test]
+    fn falls_back_to_inline_cache_when_persist_resolved_slides_are_all_textless() {
+        // Persist resolution structurally succeeds (valid directory, valid
+        // Slide offset) but the resolved Slide container has no extractable
+        // text at all — as happens when directory corruption points at the
+        // wrong offset. The SlideListWithText's own inline cache does have
+        // real text, so it must be used instead of returning nothing.
+        let mut stream = Vec::new();
+
+        let doc_offset = stream.len() as u32;
+        let mut slide_list_children = slide_persist_atom_bytes(2, 256);
+        slide_list_children.extend(make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes()));
+        slide_list_children.extend(make_atom(RT_TEXT_BYTES, 0, b"FALLBACK CACHE TEXT"));
+        let slide_list = make_container(RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, &slide_list_children);
+        stream.extend(make_container(RT_DOCUMENT, 0, &slide_list));
+
+        // A resolvable but genuinely empty Slide container (no shapes at all).
+        let real_slide_offset = stream.len() as u32;
+        stream.extend(make_container(RT_SLIDE, 0, &[]));
+
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, doc_offset), (2, real_slide_offset)]));
+        let edit_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+        let current_user = current_user_bytes(edit_offset);
+
+        let slides = extract_slides_text(&stream, Some(&current_user));
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].text_runs[0].text, "FALLBACK CACHE TEXT");
     }
 }

--- a/src/ppt/text.rs
+++ b/src/ppt/text.rs
@@ -1,6 +1,10 @@
 //! Text extraction from PPT binary records.
 
+use super::persist::{self, PersistDirectory};
 use super::records::*;
+
+/// Guards against pathologically deep (or maliciously crafted) shape nesting.
+const MAX_SHAPE_DEPTH: usize = 64;
 
 /// Text type from TextHeaderAtom.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,100 +53,163 @@ pub struct TextRun {
     pub text: String,
 }
 
-/// Extract text runs from a "PowerPoint Document" stream.
+/// Extract per-slide text from a "PowerPoint Document" stream.
 ///
-/// This walks the record tree looking for TextHeaderAtom + TextCharsAtom/TextBytesAtom pairs.
-pub fn extract_text_runs(data: &[u8]) -> Vec<TextRun> {
+/// `current_user` is the raw "Current User" stream, if present.
+///
+/// PPT97 files are saved incrementally: a slide's *current* content lives in
+/// a `Slide` container located via the persist object directory, not
+/// necessarily wherever a naive front-to-back scan first stumbles on
+/// slide-shaped data (stale, superseded copies of records are routinely left
+/// behind in the stream by earlier saves). This resolves each slide through
+/// that directory — see the `persist` module — falling back to weaker
+/// heuristics only when a usable directory can't be built at all (e.g. a
+/// minimal hand-built stream that never went through a real save cycle).
+pub fn extract_slides_text(stream: &[u8], current_user: Option<&[u8]>) -> Vec<SlideText> {
+    if let Some(dir) = persist::build(stream, current_user) {
+        if let Some(slides) = extract_slides_via_persist(stream, &dir) {
+            if !slides.is_empty() {
+                return slides;
+            }
+        }
+    }
+
+    if let Some(slide_list) = find_descendant(stream, RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, 0) {
+        let slides = extract_slides_from_slide_list_cache(&slide_list);
+        if !slides.is_empty() {
+            return slides;
+        }
+    }
+
+    // Last resort: no resolvable structure at all — dump whatever text atoms
+    // exist anywhere in the stream as a single slide.
     let mut runs = Vec::new();
+    extract_shape_text(stream, 0, &mut runs);
+    if runs.is_empty() {
+        Vec::new()
+    } else {
+        vec![SlideText { text_runs: runs }]
+    }
+}
+
+/// Resolve the current "Slides" list through the persist directory and
+/// extract each slide's shape text from its resolved `Slide` container.
+///
+/// Returns `None` if the `DocumentContainer` or its slide list can't be
+/// resolved at all (directory present but unusable); returns `Some(vec![])`
+/// if the slide list resolves but is empty.
+fn extract_slides_via_persist(stream: &[u8], dir: &PersistDirectory) -> Option<Vec<SlideText>> {
+    let doc_offset = dir.resolve(dir.doc_persist_id)?;
+    let doc_children = bounded_container_children(stream, doc_offset, RT_DOCUMENT)?;
+    let slide_list = find_child(&doc_children, RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES)?;
+
+    let mut slides = Vec::new();
+    for rec in RecordIter::new(&slide_list) {
+        let Ok(rec) = rec else { break };
+        if rec.header.rec_type != RT_SLIDE_PERSIST_ATOM || rec.data.len() < 4 {
+            continue;
+        }
+        let persist_id_ref =
+            u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
+
+        let mut text_runs = Vec::new();
+        if let Some(offset) = dir.resolve(persist_id_ref) {
+            if let Some(children) = bounded_container_children(stream, offset, RT_SLIDE) {
+                extract_shape_text(&children, 0, &mut text_runs);
+            }
+        }
+
+        // Every persist-directory-resolved slide is kept regardless of
+        // whether text was found — an image-only slide is still a slide,
+        // and the presentation's true slide count matters for numbering.
+        slides.push(SlideText { text_runs });
+    }
+
+    Some(slides)
+}
+
+/// Recursively collect `TextHeaderAtom` + `TextCharsAtom`/`TextBytesAtom`
+/// pairs from a bounded record region (a resolved `Slide`/`Notes`/`MainMaster`
+/// container's own children), in document order.
+///
+/// Bounded per [`RecordIter`]'s container semantics: a corrupted/oversized
+/// length on one shape can, at worst, truncate the remaining shapes within
+/// that *same* container — it can never affect anything outside the region
+/// this function was called with.
+fn extract_shape_text(data: &[u8], depth: usize, out: &mut Vec<TextRun>) {
+    if depth > MAX_SHAPE_DEPTH {
+        return;
+    }
     let mut current_type = TextType::Other;
 
     for rec in RecordIter::new(data) {
-        let rec = match rec {
-            Ok(r) => r,
-            Err(_) => break,
-        };
-
+        let Ok(rec) = rec else { break };
         match rec.header.rec_type {
             RT_TEXT_HEADER if rec.data.len() >= 4 => {
                 let t = u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
                 current_type = TextType::from_u32(t);
             },
             RT_TEXT_CHARS => {
-                // UTF-16LE text.
                 let text = decode_utf16le(&rec.data);
                 if !text.is_empty() {
-                    runs.push(TextRun {
+                    out.push(TextRun {
                         text_type: current_type,
                         text,
                     });
                 }
             },
             RT_TEXT_BYTES => {
-                // Compressed Latin-1 text.
                 let text: String = rec.data.iter().map(|&b| b as char).collect();
                 if !text.is_empty() {
-                    runs.push(TextRun {
+                    out.push(TextRun {
                         text_type: current_type,
                         text,
                     });
                 }
             },
-            RT_CSTRING => {
-                // UTF-16LE string (used for some metadata).
-                let text = decode_utf16le(&rec.data);
-                if !text.is_empty() {
-                    runs.push(TextRun {
-                        text_type: current_type,
-                        text,
-                    });
-                }
+            _ if rec.header.is_container() => {
+                extract_shape_text(&rec.data, depth + 1, out);
             },
             _ => {},
         }
     }
-
-    runs
 }
 
-/// Extract text grouped by slide from the SlideListWithText containers.
-///
-/// Each SlideListWithText container holds text for multiple slides,
-/// separated by SlidePersistAtom records.
-pub fn extract_slides_text(data: &[u8]) -> Vec<SlideText> {
+/// Fallback used only when the persist directory can't be resolved at all:
+/// derive slide boundaries from a `SlideListWithText`'s own inline text cache
+/// — a `SlidePersistAtom` optionally followed directly by up to 8
+/// `TextHeaderAtom` + `TextCharsAtom`/`TextBytesAtom` pairs ([MS-PPT]
+/// 2.4.14.3). This cache is optional, capped, and not authoritative (the
+/// resolved `Slide` container is the source of truth) — real-world files
+/// routinely leave it empty, which is why this is a fallback and not the
+/// primary path.
+fn extract_slides_from_slide_list_cache(slide_list: &[u8]) -> Vec<SlideText> {
     let mut slides: Vec<SlideText> = Vec::new();
-    let mut current_slide: Option<SlideText> = None;
-    let mut in_slide_list = false;
+    let mut current: Option<SlideText> = None;
     let mut current_type = TextType::Other;
 
-    for rec in RecordIter::new(data) {
-        let rec = match rec {
-            Ok(r) => r,
-            Err(_) => break,
-        };
-
+    for rec in RecordIter::new(slide_list) {
+        let Ok(rec) = rec else { break };
         match rec.header.rec_type {
-            RT_SLIDE_LIST_WITH_TEXT => {
-                in_slide_list = true;
-            },
-            RT_SLIDE_PERSIST_ATOM if in_slide_list => {
-                // New slide starts.
-                if let Some(slide) = current_slide.take() {
+            RT_SLIDE_PERSIST_ATOM => {
+                if let Some(slide) = current.take() {
                     if !slide.text_runs.is_empty() {
                         slides.push(slide);
                     }
                 }
-                current_slide = Some(SlideText {
+                current = Some(SlideText {
                     text_runs: Vec::new(),
                 });
+                current_type = TextType::Other;
             },
-            RT_TEXT_HEADER if in_slide_list && rec.data.len() >= 4 => {
+            RT_TEXT_HEADER if rec.data.len() >= 4 => {
                 let t = u32::from_le_bytes([rec.data[0], rec.data[1], rec.data[2], rec.data[3]]);
                 current_type = TextType::from_u32(t);
             },
-            RT_TEXT_CHARS if in_slide_list => {
-                let text = decode_utf16le(&rec.data);
-                if !text.is_empty() {
-                    if let Some(slide) = &mut current_slide {
+            RT_TEXT_CHARS => {
+                if let Some(slide) = current.as_mut() {
+                    let text = decode_utf16le(&rec.data);
+                    if !text.is_empty() {
                         slide.text_runs.push(TextRun {
                             text_type: current_type,
                             text,
@@ -150,10 +217,10 @@ pub fn extract_slides_text(data: &[u8]) -> Vec<SlideText> {
                     }
                 }
             },
-            RT_TEXT_BYTES if in_slide_list => {
-                let text: String = rec.data.iter().map(|&b| b as char).collect();
-                if !text.is_empty() {
-                    if let Some(slide) = &mut current_slide {
+            RT_TEXT_BYTES => {
+                if let Some(slide) = current.as_mut() {
+                    let text: String = rec.data.iter().map(|&b| b as char).collect();
+                    if !text.is_empty() {
                         slide.text_runs.push(TextRun {
                             text_type: current_type,
                             text,
@@ -165,22 +232,60 @@ pub fn extract_slides_text(data: &[u8]) -> Vec<SlideText> {
         }
     }
 
-    // Push last slide.
-    if let Some(slide) = current_slide {
+    if let Some(slide) = current {
         if !slide.text_runs.is_empty() {
             slides.push(slide);
         }
     }
 
-    // If no SlideListWithText structure found, fall back to all text runs.
-    if slides.is_empty() {
-        let runs = extract_text_runs(data);
-        if !runs.is_empty() {
-            slides.push(SlideText { text_runs: runs });
+    slides
+}
+
+/// Bounded children of the container at `offset`, if it is one of type `rec_type`.
+fn bounded_container_children(stream: &[u8], offset: usize, rec_type: u16) -> Option<Vec<u8>> {
+    let header = RecordHeader::parse(stream.get(offset..offset + 8)?).ok()?;
+    if header.rec_type != rec_type || !header.is_container() {
+        return None;
+    }
+    let start = offset + 8;
+    let end = start
+        .saturating_add(header.rec_len as usize)
+        .min(stream.len());
+    Some(stream.get(start..end)?.to_vec())
+}
+
+/// Single-level search for a direct child record matching `rec_type` and
+/// `instance`, returning its bounded children.
+fn find_child(data: &[u8], rec_type: u16, instance: u16) -> Option<Vec<u8>> {
+    for rec in RecordIter::new(data) {
+        let Ok(rec) = rec else { break };
+        if rec.header.rec_type == rec_type && rec.header.rec_instance == instance {
+            return Some(rec.data);
         }
     }
+    None
+}
 
-    slides
+/// Bounded recursive search for a descendant record matching `rec_type` and
+/// `instance`, returning its bounded children. Only used by the legacy
+/// fallback path, where the structure isn't guaranteed to place the target at
+/// any particular depth.
+fn find_descendant(data: &[u8], rec_type: u16, instance: u16, depth: usize) -> Option<Vec<u8>> {
+    if depth > MAX_SHAPE_DEPTH {
+        return None;
+    }
+    for rec in RecordIter::new(data) {
+        let Ok(rec) = rec else { break };
+        if rec.header.rec_type == rec_type && rec.header.rec_instance == instance {
+            return Some(rec.data);
+        }
+        if rec.header.is_container() {
+            if let Some(found) = find_descendant(&rec.data, rec_type, instance, depth + 1) {
+                return Some(found);
+            }
+        }
+    }
+    None
 }
 
 /// Text content of a single slide.
@@ -228,7 +333,8 @@ mod tests {
         let mut stream = make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes());
         // "Hi" in UTF-16LE
         stream.extend(make_atom(RT_TEXT_CHARS, 0, &[0x48, 0x00, 0x69, 0x00]));
-        let runs = extract_text_runs(&stream);
+        let mut runs = Vec::new();
+        extract_shape_text(&stream, 0, &mut runs);
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].text, "Hi");
         assert_eq!(runs[0].text_type, TextType::Title);
@@ -238,7 +344,8 @@ mod tests {
     fn extract_text_bytes() {
         let mut stream = make_atom(RT_TEXT_HEADER, 0, &1u32.to_le_bytes()); // Body
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Hello World"));
-        let runs = extract_text_runs(&stream);
+        let mut runs = Vec::new();
+        extract_shape_text(&stream, 0, &mut runs);
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].text, "Hello World");
         assert_eq!(runs[0].text_type, TextType::Body);
@@ -250,14 +357,34 @@ mod tests {
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Title"));
         stream.extend(make_atom(RT_TEXT_HEADER, 0, &1u32.to_le_bytes()));
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Body text"));
-        let runs = extract_text_runs(&stream);
+        let mut runs = Vec::new();
+        extract_shape_text(&stream, 0, &mut runs);
         assert_eq!(runs.len(), 2);
         assert_eq!(runs[0].text, "Title");
         assert_eq!(runs[1].text, "Body text");
     }
 
     #[test]
-    fn extract_slides_from_slide_list() {
+    fn extract_text_from_nested_shape_containers() {
+        // Text nested a few containers deep (shape -> group -> textbox),
+        // as it actually appears inside a real Slide record.
+        let header = make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes());
+        let mut textbox_children = header;
+        textbox_children.extend(make_atom(RT_TEXT_BYTES, 0, b"Nested"));
+        let textbox = make_container(0xF00D, 0, &textbox_children); // ClientTextbox
+        let shape = make_container(0xF004, 0, &textbox); // shape container
+
+        let mut runs = Vec::new();
+        extract_shape_text(&shape, 0, &mut runs);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "Nested");
+    }
+
+    /// Fallback path only: when there's no resolvable persist directory at
+    /// all, slide boundaries are derived from a `SlideListWithText`'s own
+    /// inline text cache.
+    #[test]
+    fn slide_list_cache_fallback_without_persist_directory() {
         // Build a SlideListWithText container with 2 slides.
         let mut children = Vec::new();
         // Slide 1
@@ -269,8 +396,8 @@ mod tests {
         children.extend(make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes()));
         children.extend(make_atom(RT_TEXT_BYTES, 0, b"Slide 2 Title"));
 
-        let stream = make_container(RT_SLIDE_LIST_WITH_TEXT, 0, &children);
-        let slides = extract_slides_text(&stream);
+        let stream = make_container(RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, &children);
+        let slides = extract_slides_text(&stream, None);
         assert_eq!(slides.len(), 2);
         assert_eq!(slides[0].text_runs[0].text, "Slide 1 Title");
         assert_eq!(slides[1].text_runs[0].text, "Slide 2 Title");
@@ -292,11 +419,178 @@ mod tests {
 
     #[test]
     fn fallback_when_no_slide_list() {
-        // Just raw text atoms without SlideListWithText.
+        // Just raw text atoms without SlideListWithText or a persist directory.
         let mut stream = make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes());
         stream.extend(make_atom(RT_TEXT_BYTES, 0, b"Fallback text"));
-        let slides = extract_slides_text(&stream);
+        let slides = extract_slides_text(&stream, None);
         assert_eq!(slides.len(), 1);
         assert_eq!(slides[0].text_runs[0].text, "Fallback text");
+    }
+
+    // ── Persist-directory resolution correctness ──
+    // A minimal synthetic fixture (per CONTRIBUTING.md — no third-party
+    // documents committed as fixtures) covering two defect classes an
+    // incrementally-resaved PPT97 stream can trigger:
+    //   1. A stale/orphaned Slide-shaped block left behind by an earlier save
+    //      (unreferenced by the persist directory) must be ignored in favor
+    //      of the *current*, persist-directory-resolved Slide.
+    //   2. A single record with a corrupted/oversized declared length must
+    //      not derail extraction of any later content in the stream.
+
+    fn user_edit_atom_bytes(
+        offset_last_edit: u32,
+        offset_persist_directory: u32,
+        doc_persist_id_ref: u32,
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0u32.to_le_bytes()); // lastSlideIdRef
+        body.extend_from_slice(&0u32.to_le_bytes()); // version/minor/major
+        body.extend_from_slice(&offset_last_edit.to_le_bytes());
+        body.extend_from_slice(&offset_persist_directory.to_le_bytes());
+        body.extend_from_slice(&doc_persist_id_ref.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // persistIdSeed
+        body.extend_from_slice(&0u32.to_le_bytes()); // lastView + unused
+        make_atom(RT_USER_EDIT_ATOM, 0, &body)
+    }
+
+    fn persist_directory_bytes(entries: &[(u32, u32)]) -> Vec<u8> {
+        let persist_id = entries[0].0;
+        let c_persist = entries.len() as u32;
+        let header = persist_id | (c_persist << 20);
+        let mut body = header.to_le_bytes().to_vec();
+        for (_, off) in entries {
+            body.extend_from_slice(&off.to_le_bytes());
+        }
+        make_atom(RT_PERSIST_DIRECTORY_ATOM, 0, &body)
+    }
+
+    fn current_user_bytes(offset_to_current_edit: u32) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0u32.to_le_bytes()); // size
+        body.extend_from_slice(&0u32.to_le_bytes()); // headerToken
+        body.extend_from_slice(&offset_to_current_edit.to_le_bytes());
+        body.extend_from_slice(&0u16.to_le_bytes()); // lenUserName
+        body.extend_from_slice(&0u16.to_le_bytes()); // docFileVersion
+        body.push(0); // majorVersion
+        body.push(0); // minorVersion
+        body.extend_from_slice(&0u16.to_le_bytes()); // unused
+        make_atom(RT_CURRENT_USER_ATOM, 0, &body)
+    }
+
+    fn slide_persist_atom_bytes(persist_id_ref: u32, slide_id: u32) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&persist_id_ref.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // flags/reserved
+        body.extend_from_slice(&0u32.to_le_bytes()); // cTexts
+        body.extend_from_slice(&slide_id.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // reserved3
+        make_atom(RT_SLIDE_PERSIST_ATOM, 0, &body)
+    }
+
+    fn slide_container_bytes(title: &str) -> Vec<u8> {
+        let header = make_atom(RT_TEXT_HEADER, 0, &0u32.to_le_bytes());
+        let mut textbox_children = header;
+        textbox_children.extend(make_atom(RT_TEXT_BYTES, 0, title.as_bytes()));
+        let textbox = make_container(0xF00D, 0, &textbox_children); // ClientTextbox
+        make_container(RT_SLIDE, 0, &textbox)
+    }
+
+    /// Builds a synthetic "PowerPoint Document" stream containing a
+    /// stale/orphaned slide-shaped block the persist directory does *not*
+    /// reference, followed by the real (persist-resolved)
+    /// Document/SlideListWithText/Slide structure, with an empty inline text
+    /// cache in the SlideListWithText — the shape incrementally-resaved
+    /// real-world files routinely take. Returns `(stream, current_user_stream)`.
+    fn build_persist_regression_fixture() -> (Vec<u8>, Vec<u8>) {
+        let mut stream = Vec::new();
+
+        // Stale, orphaned copy of slide-shaped content — not in the persist
+        // directory, so it must never appear in extracted output.
+        stream.extend(slide_container_bytes("DECOY STALE TEXT"));
+
+        // DocumentContainer (persist id 1), with an empty inline text cache.
+        let doc_offset = stream.len() as u32;
+        let slide_persist = slide_persist_atom_bytes(2, 256);
+        let slide_list = make_container(RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, &slide_persist);
+        stream.extend(make_container(RT_DOCUMENT, 0, &slide_list));
+
+        // The real, current Slide container (persist id 2).
+        let real_slide_offset = stream.len() as u32;
+        stream.extend(slide_container_bytes("REAL SLIDE TEXT"));
+
+        // Persist directory + user edit atom.
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, doc_offset), (2, real_slide_offset)]));
+        let edit_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+
+        let current_user = current_user_bytes(edit_offset);
+        (stream, current_user)
+    }
+
+    #[test]
+    fn persist_resolution_ignores_stale_orphaned_slide_copy() {
+        let (stream, current_user) = build_persist_regression_fixture();
+        let slides = extract_slides_text(&stream, Some(&current_user));
+
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].text_runs[0].text, "REAL SLIDE TEXT");
+        assert!(
+            !slides
+                .iter()
+                .flat_map(|s| &s.text_runs)
+                .any(|r| r.text.contains("DECOY")),
+            "stale orphaned copy must not appear in extracted text"
+        );
+    }
+
+    #[test]
+    fn persist_resolution_works_without_current_user_stream() {
+        let (stream, _current_user) = build_persist_regression_fixture();
+        let slides = extract_slides_text(&stream, None);
+
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].text_runs[0].text, "REAL SLIDE TEXT");
+    }
+
+    fn corrupt_record() -> Vec<u8> {
+        // A top-level record declaring a wildly oversized length with no
+        // data behind it, as produced by non-conformant real-world PPT97
+        // writers.
+        let mut corrupt = Vec::new();
+        corrupt.extend_from_slice(&0u16.to_le_bytes()); // ver=0 (atom)
+        corrupt.extend_from_slice(&RT_TEXT_CHARS.to_le_bytes());
+        corrupt.extend_from_slice(&5_000_000u32.to_le_bytes()); // bogus length
+        corrupt
+    }
+
+    #[test]
+    fn corrupted_record_length_before_real_content_does_not_lose_it() {
+        // Same shape as build_persist_regression_fixture, with a corrupt
+        // top-level record spliced in right after the stale block.
+        let mut stream = Vec::new();
+        stream.extend(slide_container_bytes("DECOY STALE TEXT"));
+        stream.extend(corrupt_record());
+
+        let doc_offset = stream.len() as u32;
+        let slide_persist = slide_persist_atom_bytes(2, 256);
+        let slide_list = make_container(RT_SLIDE_LIST_WITH_TEXT, SLWT_SLIDES, &slide_persist);
+        stream.extend(make_container(RT_DOCUMENT, 0, &slide_list));
+
+        let real_slide_offset = stream.len() as u32;
+        stream.extend(slide_container_bytes("REAL SLIDE TEXT"));
+
+        let pd_offset = stream.len() as u32;
+        stream.extend(persist_directory_bytes(&[(1, doc_offset), (2, real_slide_offset)]));
+        let edit_offset = stream.len() as u32;
+        stream.extend(user_edit_atom_bytes(0, pd_offset, 1));
+        let current_user = current_user_bytes(edit_offset);
+
+        let slides = extract_slides_text(&stream, Some(&current_user));
+        assert_eq!(slides.len(), 1);
+        assert_eq!(
+            slides[0].text_runs[0].text, "REAL SLIDE TEXT",
+            "a corrupted record's length must not prevent later real content from being found"
+        );
     }
 }


### PR DESCRIPTION
## Linked issue

Closes #85

## What and why

`PlainText()`/`ToMarkdown()`/`ToIRJSON()` on legacy binary `.ppt` files could
return embedded hyperlink paths and internal OLE/metadata tokens instead of
real slide text, sometimes collapsing a multi-slide deck into a single wrong
"slide". Root cause: the ppt text extractor scanned the "PowerPoint Document"
stream front-to-back and trusted whatever slide-shaped data it found first.
PPT97 files are saved incrementally, so stale/superseded copies of records
are routinely left behind in the stream — a naive scan can't tell current
content from orphaned leftovers. A single record with a corrupted/oversized
declared length could also derail the scan entirely, since the record
iterator bounded child data against the whole stream rather than each
record's own enclosing container.

Fix: resolve each slide's *current* content through the PPT97 persist object
directory (`Current User` stream → `UserEditAtom` chain →
`PersistDirectoryAtom`, per [MS-PPT]) instead of scanning blind, and bound
the record iterator per-record so a corrupted length can't swallow bytes
belonging to later, unrelated records. Also resolves `OutlineTextRefAtom`
indirection — many placeholder shapes store their text only as an index back
into the slide's own outline-text cache rather than embedding it directly —
which running against a real-world corpus showed was needed for correctness,
not just the reported bug.

## Type of change

- [x] Bug fix

## Tests

- [x] Added tests that fail before this change and pass after (minimal
      synthetic PPT97 streams built in code — no third-party file committed,
      per the fixture rule).
- [x] Tests named by defect class (e.g.
      `persist_resolution_ignores_stale_orphaned_slide_copy`,
      `corrupted_record_length_before_real_content_does_not_lose_it`,
      `outline_text_ref_atom_resolves_indexed_placeholder_text`), not by
      issue/PR number.
- [x] `cargo test --workspace` passes (lib + all integration test crates +
      doctests).
- [x] `cargo fmt --check` and `cargo clippy --all-targets` are clean.

## Regression on real Office files

**Corpus I tested**: 176 real-world `.ppt` files from my local
`office_oxide_tests` corpus (LibreOffice QA data, Apache POI/Tika test
resources, and OSS-Fuzz/clusterfuzz-minimized regression cases).

- [x] Ran `text` extraction over the corpus on this branch vs. `main` (release
      builds of both) — compared per-file exit code and extracted text.
- [x] Checked against latest release (`main` at the time = v0.1.7, same
      commit the release tag points at).

**Diff summary**: 0 crashes either side. 1 file lost content going to empty
(`41384.ppt`) — inspected: the lost text was `___PPT10` (an internal marker,
literally the same class of token named in issue #85) and a template/theme
name, i.e. pure metadata, not slide content. 127 files had different
(non-empty→non-empty) output — spot-checked the largest deltas: in every case
the new output is a superset of the old with duplicated/stale content
collapsed (one file went from 1168 lines / 114 unique to the 114 unique lines
plus previously-missing chart/table labels the old flat scan never reached).
4 files went from empty to non-empty, all plausible real content (fuzzer test
decks with deliberate placeholder text like "Bla bla bla" / "First slide I
added"). No garbled/mojibake output observed in spot checks.

## AI assistance disclosure

- [x] AI assistance: **assisted** — tool: Claude Code. Extent: root-cause
      investigation (including a subagent that verified the PPT97 persist
      directory byte layout against Apache POI and the live [MS-PPT] spec),
      implementation, test authoring, and the corpus regression run above,
      all directed and reviewed interactively by me.
- [x] I understand and can explain every line.

## Checklist

- [x] One logical change (ppt text extraction correctness; no bundled
      refactor/perf work).
- [x] Commits follow Conventional Commits.
- [ ] CLA (n/a — repo owner).
- [ ] Docs/CHANGELOG — will update on release.
