### PR TITLE
Release v0.1.8 — PPT97 persist-directory text extraction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-07-22
+
+> PPT97 (legacy binary `.ppt`) text-extraction correctness release. No breaking API changes.
+
+### Fixed
+
+- **PPT: `PlainText()` / `ToMarkdown()` / `ToIRJSON()` no longer return stale or embedded-metadata text instead of real slide content on legacy binary `.ppt` files ([#85](https://github.com/yfedoseev/office_oxide/issues/85)).** PPT97 uses incremental ("fast") saves — each save appends new/changed records to the end of the "PowerPoint Document" stream, leaving superseded copies of earlier records (e.g. a pre-edit `Slide` container) behind in the stream with nothing to compact them away. The extractor scanned front-to-back and trusted whichever slide-shaped data it found first, so stale leftovers could win over current content, and in the worst case a corrupted/oversized declared record length (the record iterator bounded child data against the whole stream rather than its own enclosing container) could derail the scan and swallow unrelated later records. Slide content is now resolved through the PPT97 persist object directory instead — `Current User` stream → `UserEditAtom` chain (`offsetLastEdit`) → merged `PersistDirectoryAtom` entries, per [MS-PPT] 2.1.2 — so the *current* copy of each slide's records is used regardless of scan order, and the record iterator now bounds each record against its own container. Also resolves `OutlineTextRefAtom` indirection, where a placeholder shape stores text only as an index back into the slide's outline-text cache rather than embedding it directly — needed for correctness against a real-world corpus, not just the reported bug. Verified against 176 real-world `.ppt` files (LibreOffice QA data, Apache POI/Tika test resources, OSS-Fuzz regression cases): zero crashes either side vs. v0.1.7, and every file with changed output gained previously-missing content (stale duplicates collapsed, indexed placeholder text now resolved) with no garbled output observed. Thanks to the reporter of #85.
+
 ## [0.1.7] - 2026-07-19
 
 > Round-trip and robustness release: the write↔parse IR cycle is now a fixed point for DOCX/PPTX, oversized XLSX sheets are bounded instead of stalling, plus the earlier XLSX cell-type/DOCX-truncation/XLSX-edit fixes, a dependency refresh, and CI-hardening + IP-governance groundwork. No breaking API changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "atoi_simd",
  "encoding_rs",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "office_oxide",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "office_oxide_mcp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "office_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ match_like_matches_macro = "allow"
 manual_find = "allow"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yfedoseev/office_oxide"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ let ir = doc.to_ir(); // Format-agnostic intermediate representation
 
 ```toml
 [dependencies]
-office_oxide = "0.1.7"
+office_oxide = "0.1.8"
 ```
 
 ### JavaScript / WASM
@@ -309,7 +309,7 @@ Wheels available for Linux, macOS, and Windows. Python 3.8–3.14.
 
 ```toml
 [dependencies]
-office_oxide = "0.1.7"
+office_oxide = "0.1.8"
 ```
 
 ### JavaScript/WASM

--- a/crates/office_oxide_cli/Cargo.toml
+++ b/crates/office_oxide_cli/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.7", path = "../.." }
+office_oxide = { version = "0.1.8", path = "../.." }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/office_oxide_mcp/Cargo.toml
+++ b/crates/office_oxide_mcp/Cargo.toml
@@ -21,7 +21,7 @@ name = "office-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-office_oxide = { version = "0.1.7", path = "../.." }
+office_oxide = { version = "0.1.8", path = "../.." }
 serde_json = "1"
 
 [package.metadata.binstall]

--- a/csharp/OfficeOxide/OfficeOxide.csproj
+++ b/csharp/OfficeOxide/OfficeOxide.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PackageId>OfficeOxide</PackageId>
-    <Version>0.1.7</Version>
+    <Version>0.1.8</Version>
     <Title>OfficeOxide</Title>
     <Authors>Yury Fedoseev</Authors>
     <Product>office_oxide</Product>

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -8,7 +8,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-office_oxide = "0.1.7"
+office_oxide = "0.1.8"
 ```
 
 ### Feature Flags
@@ -16,7 +16,7 @@ office_oxide = "0.1.7"
 ```toml
 [dependencies]
 # Default build — full read/write/edit support for all six formats.
-office_oxide = "0.1.7"
+office_oxide = "0.1.8"
 
 # Memory-mapped opens for large OOXML files.
 office_oxide = { version = "0.1.6", features = ["mmap"] }

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Bumped in lockstep with the Rust crate.
-const defaultVersion = "0.1.7"
+const defaultVersion = "0.1.8"
 
 const releaseBase = "https://github.com/yfedoseev/office_oxide/releases/download"
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) for Node.js — native bindings backed by the Rust office_oxide library.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "office-oxide"
-version = "0.1.7"
+version = "0.1.8"
 description = "The fastest Office document processing library for Python — DOCX, XLSX, PPTX, DOC, XLS, PPT"
 requires-python = ">=3.8"
 license = { text = "MIT OR Apache-2.0" }

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-oxide-wasm",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Fast Office document processing (DOCX/XLSX/PPTX/DOC/XLS/PPT) compiled to WebAssembly. Rust core, zero JS dependencies. Works in Node.js, bundlers, and browsers.",
   "license": "MIT OR Apache-2.0",
   "author": "Yury Fedoseev",


### PR DESCRIPTION
## Summary
- Bumps version 0.1.7 → 0.1.8 across every shipping manifest (Cargo.toml/Cargo.lock, pyproject.toml, wasm-pkg & js package.json, C# csproj, Go installer default) plus README/docs snippets.
- Adds the CHANGELOG entry for 0.1.8 (2026-07-22), covering the only change since v0.1.7: the PPT97 persist-directory text-extraction fix (#85, #86).

## Test plan
- [x] `.github/scripts/check-versions.sh` — all manifests report 0.1.8
- [x] `.github/scripts/extract-release-notes.sh 0.1.8` — CHANGELOG entry extracts cleanly
- [x] `cargo build --workspace` — compiles clean at 0.1.8
- [ ] CI green on this PR