### PR TITLE
Improve .doc/.pptx preview: embedded images, tables, encryption detection, hidden-shape fix

### DIFF
--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -31,9 +31,22 @@ fn image_element(img: &crate::doc::DocImage) -> Element {
 /// (Heuristic: office_oxide's .doc reader has no PAPX layer to read the real
 /// fInTable/fTtp flags, but this reproduces the row/cell structure for typical
 /// tables. Tables containing adjacent empty cells can't be disambiguated this way.)
-fn doc_table_rows(line: &str) -> Vec<TableRow> {
+fn doc_table(line: &str) -> (Vec<TableRow>, Option<String>) {
+    let mut segs: Vec<&str> = line.split("\t\t").collect();
+    // Every real table row ends with the row-end mark, so a clean table produces an
+    // empty final segment. A NON-empty final segment is the paragraph that follows
+    // the table on the same text line (e.g. an introductory sentence) — pull it out
+    // so it isn't mistaken for a one-cell row.
+    let trailing = match segs.last() {
+        Some(s) if !s.trim().is_empty() => segs.pop().map(|s| s.to_string()),
+        _ => {
+            segs.pop();
+            None
+        },
+    };
+
     let mut rows: Vec<TableRow> = Vec::new();
-    for row_str in line.split("\t\t") {
+    for row_str in segs {
         let mut cells_txt: Vec<&str> = row_str.split('\t').collect();
         while cells_txt.last().is_some_and(|c| c.trim().is_empty()) {
             cells_txt.pop();
@@ -58,7 +71,7 @@ fn doc_table_rows(line: &str) -> Vec<TableRow> {
             .collect();
         rows.push(TableRow { cells, ..Default::default() });
     }
-    rows
+    (rows, trailing)
 }
 
 fn text_element(text: &str, is_first: bool) -> Element {
@@ -100,9 +113,19 @@ pub(crate) fn doc_to_ir(doc: &crate::doc::DocDocument) -> DocumentIR {
         // A "\t\t" run marks a flattened table (cell mark + row-end mark). Emit a
         // real IR table so it renders as a bordered grid instead of tab text.
         if line.contains("\t\t") {
-            let rows = doc_table_rows(line);
+            let (rows, trailing) = doc_table(line);
+            let handled = !rows.is_empty() || trailing.is_some();
             if !rows.is_empty() {
                 elements.push(Element::Table(Table { rows, ..Default::default() }));
+            }
+            // The sentence that followed the table on the same line becomes its
+            // own paragraph rather than a stray one-cell row.
+            if let Some(t) = trailing {
+                if !t.trim().is_empty() {
+                    elements.push(text_element(&t, elements.is_empty()));
+                }
+            }
+            if handled {
                 continue;
             }
         }

--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -1,66 +1,87 @@
 use crate::format::DocumentFormat;
 use crate::ir::*;
 
+/// Maps a Data-stream BLIP image to an IR `Element::Image` carrying the decoded
+/// bytes (the HTML renderer inlines them as a data: URI; see ir_render.rs).
+fn image_element(img: &crate::doc::DocImage) -> Element {
+    use crate::cfb::blip::BlipFormat;
+    let format = match img.format {
+        BlipFormat::Png => Some(ImageFormat::Png),
+        BlipFormat::Jpeg => Some(ImageFormat::Jpeg),
+        BlipFormat::Dib => Some(ImageFormat::Bmp),
+        BlipFormat::Tiff => Some(ImageFormat::Tiff),
+        BlipFormat::Emf => Some(ImageFormat::Emf),
+        BlipFormat::Wmf => Some(ImageFormat::Wmf),
+        BlipFormat::Pict | BlipFormat::Unknown(_) => None,
+    };
+    Element::Image(Image {
+        data: Some(img.data.clone()),
+        format,
+        positioning: ImagePositioning::Inline,
+        ..Default::default()
+    })
+}
+
+fn text_element(text: &str, is_first: bool) -> Element {
+    // Heuristic: short lines in ALL CAPS, or the first line if short, are headings.
+    let trimmed = text.trim();
+    let is_heading = trimmed.len() < 100
+        && !trimmed.ends_with('.')
+        && !trimmed.ends_with(',')
+        && (trimmed.chars().filter(|c| c.is_alphabetic()).all(|c| c.is_uppercase())
+            || (is_first && trimmed.len() < 60));
+    if is_heading {
+        Element::Heading(Heading {
+            level: if is_first { 1 } else { 2 },
+            content: vec![InlineContent::Text(TextSpan { bold: true, ..TextSpan::plain(trimmed) })],
+            ..Default::default()
+        })
+    } else {
+        Element::Paragraph(Paragraph {
+            content: vec![InlineContent::Text(TextSpan::plain(text))],
+            ..Default::default()
+        })
+    }
+}
+
 pub(crate) fn doc_to_ir(doc: &crate::doc::DocDocument) -> DocumentIR {
+    // plain_text_ref() retains U+FFFC picture markers at the exact character
+    // positions of embedded images. We split the text on them and emit an
+    // Element::Image at each marker (consuming doc.images() in document order),
+    // so images land inline where they actually appear rather than lumped at the
+    // end. Any images without a marker (headers/footers, or a count mismatch) are
+    // appended so nothing is lost.
     let text = doc.plain_text_ref();
+    let images = doc.images();
+    let mut img_idx = 0usize;
 
     let mut elements: Vec<Element> = Vec::new();
 
     for line in text.lines() {
+        if line.contains('\u{FFFC}') {
+            for (i, seg) in line.split('\u{FFFC}').enumerate() {
+                if i > 0 && img_idx < images.len() {
+                    elements.push(image_element(&images[img_idx]));
+                    img_idx += 1;
+                }
+                if !seg.trim().is_empty() {
+                    elements.push(text_element(seg, elements.is_empty()));
+                }
+            }
+            continue;
+        }
+
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
-
-        // Heuristic: short lines in ALL CAPS or ending with no punctuation
-        // at the start of a section are likely headings
-        let is_heading = trimmed.len() < 100
-            && !trimmed.ends_with('.')
-            && !trimmed.ends_with(',')
-            && (trimmed
-                .chars()
-                .filter(|c| c.is_alphabetic())
-                .all(|c| c.is_uppercase())
-                || (elements.is_empty() && trimmed.len() < 60));
-
-        if is_heading {
-            elements.push(Element::Heading(Heading {
-                level: if elements.is_empty() { 1 } else { 2 },
-                content: vec![InlineContent::Text(TextSpan {
-                    bold: true,
-                    ..TextSpan::plain(trimmed)
-                })],
-                ..Default::default()
-            }));
-        } else {
-            elements.push(Element::Paragraph(Paragraph {
-                content: vec![InlineContent::Text(TextSpan::plain(line))],
-                ..Default::default()
-            }));
-        }
+        elements.push(text_element(line, elements.is_empty()));
     }
 
-    // Surface embedded images extracted from the Data stream. .doc text
-    // extraction discards the picture placeholder (\x01), so the exact inline
-    // position is not known here; the images are appended in document (BLIP
-    // scan) order so they aren't lost. Emitting Element::Image with the decoded
-    // bytes lets the HTML/markdown renderers inline them (see ir_render.rs).
-    use crate::cfb::blip::BlipFormat;
-    for img in doc.images() {
-        let format = match img.format {
-            BlipFormat::Png => Some(ImageFormat::Png),
-            BlipFormat::Jpeg => Some(ImageFormat::Jpeg),
-            BlipFormat::Dib => Some(ImageFormat::Bmp),
-            BlipFormat::Tiff => Some(ImageFormat::Tiff),
-            BlipFormat::Emf => Some(ImageFormat::Emf),
-            BlipFormat::Wmf => Some(ImageFormat::Wmf),
-            BlipFormat::Pict | BlipFormat::Unknown(_) => None,
-        };
-        elements.push(Element::Image(Image {
-            data: Some(img.data.clone()),
-            format,
-            ..Default::default()
-        }));
+    // Any remaining images had no in-text marker; append them so they aren't lost.
+    while img_idx < images.len() {
+        elements.push(image_element(&images[img_idx]));
+        img_idx += 1;
     }
 
     let title = elements.iter().find_map(|e| match e {

--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -22,6 +22,45 @@ fn image_element(img: &crate::doc::DocImage) -> Element {
     })
 }
 
+/// Reconstructs a flattened .doc table line into IR table rows. In binary Word a
+/// table cell ends with a cell mark (0x07) and each row is terminated by a
+/// table-terminating paragraph whose mark is also 0x07 — both surface as tabs in
+/// the extracted text. So within a row cells are separated by a single tab, and a
+/// row ends with "\t\t" (the last cell's mark + the row-end mark). Splitting on
+/// "\t\t" therefore yields rows, and splitting each row on "\t" yields its cells.
+/// (Heuristic: office_oxide's .doc reader has no PAPX layer to read the real
+/// fInTable/fTtp flags, but this reproduces the row/cell structure for typical
+/// tables. Tables containing adjacent empty cells can't be disambiguated this way.)
+fn doc_table_rows(line: &str) -> Vec<TableRow> {
+    let mut rows: Vec<TableRow> = Vec::new();
+    for row_str in line.split("\t\t") {
+        let mut cells_txt: Vec<&str> = row_str.split('\t').collect();
+        while cells_txt.last().is_some_and(|c| c.trim().is_empty()) {
+            cells_txt.pop();
+        }
+        if cells_txt.is_empty() {
+            continue;
+        }
+        let cells: Vec<TableCell> = cells_txt
+            .iter()
+            .map(|c| {
+                let t = c.replace('\u{FFFC}', ""); // drop any stray object marker
+                TableCell {
+                    content: vec![Element::Paragraph(Paragraph {
+                        content: vec![InlineContent::Text(TextSpan::plain(t.trim()))],
+                        ..Default::default()
+                    })],
+                    col_span: 1,
+                    row_span: 1,
+                    ..Default::default()
+                }
+            })
+            .collect();
+        rows.push(TableRow { cells, ..Default::default() });
+    }
+    rows
+}
+
 fn text_element(text: &str, is_first: bool) -> Element {
     // Heuristic: short lines in ALL CAPS, or the first line if short, are headings.
     let trimmed = text.trim();
@@ -58,6 +97,16 @@ pub(crate) fn doc_to_ir(doc: &crate::doc::DocDocument) -> DocumentIR {
     let mut elements: Vec<Element> = Vec::new();
 
     for line in text.lines() {
+        // A "\t\t" run marks a flattened table (cell mark + row-end mark). Emit a
+        // real IR table so it renders as a bordered grid instead of tab text.
+        if line.contains("\t\t") {
+            let rows = doc_table_rows(line);
+            if !rows.is_empty() {
+                elements.push(Element::Table(Table { rows, ..Default::default() }));
+                continue;
+            }
+        }
+
         if line.contains('\u{FFFC}') {
             for (i, seg) in line.split('\u{FFFC}').enumerate() {
                 if i > 0 && img_idx < images.len() {

--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -40,6 +40,29 @@ pub(crate) fn doc_to_ir(doc: &crate::doc::DocDocument) -> DocumentIR {
         }
     }
 
+    // Surface embedded images extracted from the Data stream. .doc text
+    // extraction discards the picture placeholder (\x01), so the exact inline
+    // position is not known here; the images are appended in document (BLIP
+    // scan) order so they aren't lost. Emitting Element::Image with the decoded
+    // bytes lets the HTML/markdown renderers inline them (see ir_render.rs).
+    use crate::cfb::blip::BlipFormat;
+    for img in doc.images() {
+        let format = match img.format {
+            BlipFormat::Png => Some(ImageFormat::Png),
+            BlipFormat::Jpeg => Some(ImageFormat::Jpeg),
+            BlipFormat::Dib => Some(ImageFormat::Bmp),
+            BlipFormat::Tiff => Some(ImageFormat::Tiff),
+            BlipFormat::Emf => Some(ImageFormat::Emf),
+            BlipFormat::Wmf => Some(ImageFormat::Wmf),
+            BlipFormat::Pict | BlipFormat::Unknown(_) => None,
+        };
+        elements.push(Element::Image(Image {
+            data: Some(img.data.clone()),
+            format,
+            ..Default::default()
+        }));
+    }
+
     let title = elements.iter().find_map(|e| match e {
         Element::Heading(h) => h.content.first().and_then(|c| match c {
             InlineContent::Text(t) => Some(t.text.clone()),

--- a/src/convert_pptx.rs
+++ b/src/convert_pptx.rs
@@ -140,10 +140,11 @@ fn find_title(shapes: &[crate::pptx::Shape]) -> Option<(String, Option<Paragraph
     for shape in shapes {
         match shape {
             crate::pptx::Shape::AutoShape(auto)
-                if auto
-                    .placeholder
-                    .as_ref()
-                    .is_some_and(|ph| is_title_placeholder(ph.ph_type.as_deref())) =>
+                if !auto.hidden
+                    && auto
+                        .placeholder
+                        .as_ref()
+                        .is_some_and(|ph| is_title_placeholder(ph.ph_type.as_deref())) =>
             {
                 if let Some(ref tb) = auto.text_body {
                     let text = plain_text_from_body(tb);
@@ -183,6 +184,12 @@ fn plain_text_from_body(body: &crate::pptx::TextBody) -> String {
 fn convert_shape(shape: &crate::pptx::Shape, elements: &mut Vec<Element>) {
     match shape {
         crate::pptx::Shape::AutoShape(auto) => {
+            // Skip shapes PowerPoint hides (`<p:cNvPr hidden="1">`), e.g. off-slide
+            // fingerprint/watermark text boxes — they aren't part of the visible
+            // presentation and would otherwise leak into the text preview.
+            if auto.hidden {
+                return;
+            }
             // Skip title placeholder — used as section title
             if auto
                 .placeholder
@@ -202,6 +209,9 @@ fn convert_shape(shape: &crate::pptx::Shape, elements: &mut Vec<Element>) {
             }
         },
         crate::pptx::Shape::Picture(pic) => {
+            if pic.hidden {
+                return;
+            }
             // Carry the resolved media bytes through so the PDF renderer
             // (`render_pptx_textbox_content`) can paint the actual
             // picture at its shape rectangle. `embed_rid` is preserved

--- a/src/doc/document.rs
+++ b/src/doc/document.rs
@@ -37,6 +37,12 @@ impl DocDocument {
             }, // Unsupported Word version
         };
 
+        // Password-protected documents can't be read (office_oxide has no
+        // decryption); surface a clear error rather than empty/garbage text.
+        if fib.encrypted {
+            return Err(DocError::Encrypted);
+        }
+
         // Open the appropriate table stream; try preferred first, then fallback.
         let table_stream = if fib.use_table1 {
             cfb.open_stream("1Table")

--- a/src/doc/document.rs
+++ b/src/doc/document.rs
@@ -105,12 +105,14 @@ impl DocDocument {
         &self.images
     }
 
-    /// Get the extracted plain text.
+    /// Get the extracted plain text. Picture markers (U+FFFC) are removed.
     pub fn plain_text(&self) -> String {
-        self.text.clone()
+        self.text.replace('\u{FFFC}', "")
     }
 
-    /// Get a reference to the extracted plain text.
+    /// Get a reference to the extracted plain text. Retains U+FFFC picture
+    /// markers (used by the IR conversion to position images); the public
+    /// plain_text()/to_markdown() getters strip them.
     pub fn plain_text_ref(&self) -> &str {
         &self.text
     }
@@ -120,7 +122,8 @@ impl DocDocument {
         let mut result = String::new();
         let mut prev_empty = false;
 
-        for line in self.text.lines() {
+        let clean = self.text.replace('\u{FFFC}', "");
+        for line in clean.lines() {
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 if !prev_empty {

--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -24,6 +24,10 @@ pub enum DocError {
     /// Underlying I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// The document is encrypted / password-protected and cannot be read.
+    #[error("document is encrypted")]
+    Encrypted,
 }
 
 /// Convenience `Result` alias using `DocError`.

--- a/src/doc/fib.rs
+++ b/src/doc/fib.rs
@@ -13,6 +13,8 @@ pub struct Fib {
     pub version: u16,
     /// Which table stream to use: true = "1Table", false = "0Table".
     pub use_table1: bool,
+    /// fEncrypted: the document is encrypted / password-protected.
+    pub encrypted: bool,
     /// Offset of the CLX (piece table) in the Table stream.
     pub clx_offset: u32,
     /// Size of the CLX in the Table stream.
@@ -51,8 +53,9 @@ impl Fib {
 
         let version = u16::from_le_bytes([data[2], data[3]]);
 
-        // Flags at offset 0x0A (u16): bit 9 = fWhichTblStm
+        // Flags at offset 0x0A (u16): bit 8 = fEncrypted, bit 9 = fWhichTblStm
         let flags = u16::from_le_bytes([data[0x0A], data[0x0B]]);
+        let encrypted = (flags & (1 << 8)) != 0;
         let use_table1 = (flags & (1 << 9)) != 0;
 
         // FibRgLw97 starts at offset 0x22, its size field at 0x22 (u16, should be 0x16).
@@ -90,6 +93,7 @@ impl Fib {
         Ok(Self {
             version,
             use_table1,
+            encrypted,
             clx_offset,
             clx_size,
             text_len,

--- a/src/doc/piece_table.rs
+++ b/src/doc/piece_table.rs
@@ -210,7 +210,11 @@ pub fn sanitize_text(text: &str) -> String {
             '\x07' => result.push('\t'),                      // Cell/row mark → tab
             '\x0C' => result.push('\n'),                      // Page break / section break
             '\x0B' => result.push('\n'),                      // Vertical tab → newline
-            '\x01' | '\x08' | '\x13' | '\x14' | '\x15' => {}, // Field codes, picture, etc. — skip
+            // Picture / embedded-object placeholder: keep it as U+FFFC (OBJECT
+            // REPLACEMENT CHARACTER) so downstream conversion knows where images
+            // sit in the text flow. Plain-text / markdown getters strip it.
+            '\x01' => result.push('\u{FFFC}'),
+            '\x08' | '\x13' | '\x14' | '\x15' => {}, // Field codes — skip
             _ => result.push(ch),
         }
     }

--- a/src/ir_render.rs
+++ b/src/ir_render.rs
@@ -128,24 +128,28 @@ mod block_default {
                 // When the IR carries the decoded image bytes, inline them as a
                 // self-contained data: URI so the HTML is directly renderable.
                 // Vector metafiles (EMF/WMF) are kept as empty <img> because most
-                // renderers can't display them.
+                // renderers can't display them. The <img> is wrapped in its own
+                // <p> block: a bare inline <img> between two paragraphs gets folded
+                // into the preceding block by flow renderers (e.g. Qt's
+                // QTextBrowser), which then baseline-aligns a large image and
+                // leaves big vertical gaps around the neighbouring text.
                 match (&img.data, &img.format) {
                     (Some(bytes), Some(fmt))
                         if !bytes.is_empty()
                             && !matches!(fmt, ImageFormat::Emf | ImageFormat::Wmf) =>
                     {
-                        let mut out = String::with_capacity(48 + alt.len() + bytes.len() * 4 / 3);
+                        let mut out = String::with_capacity(56 + alt.len() + bytes.len() * 4 / 3);
                         let _ = write!(
                             out,
-                            "<img alt=\"{alt}\" src=\"data:{};base64,{}\" />",
+                            "<p><img alt=\"{alt}\" src=\"data:{};base64,{}\" /></p>",
                             fmt.content_type(),
                             super::base64_encode(bytes)
                         );
                         out
                     },
                     _ => {
-                        let mut out = String::with_capacity(20 + alt.len());
-                        let _ = write!(out, "<img alt=\"{alt}\" />");
+                        let mut out = String::with_capacity(28 + alt.len());
+                        let _ = write!(out, "<p><img alt=\"{alt}\" /></p>");
                         out
                     },
                 }

--- a/src/ir_render.rs
+++ b/src/ir_render.rs
@@ -1,5 +1,23 @@
 use crate::ir::*;
 
+/// Minimal standard-base64 encoder (no dependency), used to inline embedded
+/// image bytes into HTML as `data:` URIs.
+pub(crate) fn base64_encode(data: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(TABLE[((n >> 18) & 63) as usize] as char);
+        out.push(TABLE[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 { TABLE[((n >> 6) & 63) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 2 { TABLE[(n & 63) as usize] as char } else { '=' });
+    }
+    out
+}
+
 mod block_default {
     //! Default flow-rendering for [`Element`] variants that don't
     //! carry a meaningful inline / paragraph / heading shape.
@@ -107,9 +125,30 @@ mod block_default {
                     .as_deref()
                     .map(super::escape_html)
                     .unwrap_or_default();
-                let mut out = String::with_capacity(20 + alt.len());
-                let _ = write!(out, "<img alt=\"{alt}\" />");
-                out
+                // When the IR carries the decoded image bytes, inline them as a
+                // self-contained data: URI so the HTML is directly renderable.
+                // Vector metafiles (EMF/WMF) are kept as empty <img> because most
+                // renderers can't display them.
+                match (&img.data, &img.format) {
+                    (Some(bytes), Some(fmt))
+                        if !bytes.is_empty()
+                            && !matches!(fmt, ImageFormat::Emf | ImageFormat::Wmf) =>
+                    {
+                        let mut out = String::with_capacity(48 + alt.len() + bytes.len() * 4 / 3);
+                        let _ = write!(
+                            out,
+                            "<img alt=\"{alt}\" src=\"data:{};base64,{}\" />",
+                            fmt.content_type(),
+                            super::base64_encode(bytes)
+                        );
+                        out
+                    },
+                    _ => {
+                        let mut out = String::with_capacity(20 + alt.len());
+                        let _ = write!(out, "<img alt=\"{alt}\" />");
+                        out
+                    },
+                }
             },
             Element::Heading(_)
             | Element::Paragraph(_)

--- a/src/pptx/shape.rs
+++ b/src/pptx/shape.rs
@@ -28,6 +28,10 @@ pub struct AutoShape {
     pub text_body: Option<TextBody>,
     /// Placeholder role, if this shape is a slide placeholder.
     pub placeholder: Option<PlaceholderInfo>,
+    /// `true` when `<p:cNvPr hidden="1">` marks the shape as not rendered.
+    /// Such shapes (e.g. off-slide fingerprint/watermark text boxes) must be
+    /// omitted from output, exactly as PowerPoint hides them.
+    pub hidden: bool,
 }
 
 /// An image or picture shape (`<p:pic>`).
@@ -49,6 +53,8 @@ pub struct PictureShape {
     /// Image format inferred from the relationship target extension or
     /// byte signature (e.g. `"png"`, `"jpeg"`, `"gif"`, `"emf"`).
     pub format: Option<String>,
+    /// `true` when `<p:cNvPr hidden="1">` marks the picture as not rendered.
+    pub hidden: bool,
 }
 
 /// A group of child shapes (`<p:grpSp>`).

--- a/src/pptx/slide.rs
+++ b/src/pptx/slide.rs
@@ -197,6 +197,7 @@ fn parse_auto_shape(
     let mut position = None;
     let mut text_body = None;
     let mut placeholder = None;
+    let mut hidden = false;
 
     loop {
         match reader.read_event()? {
@@ -207,6 +208,7 @@ fn parse_auto_shape(
                     name = props.1;
                     alt_text = props.2;
                     placeholder = props.3;
+                    hidden = props.4;
                 },
                 b"spPr" => {
                     position = parse_shape_properties(reader)?;
@@ -233,6 +235,7 @@ fn parse_auto_shape(
         position,
         text_body,
         placeholder,
+        hidden,
     }))
 }
 
@@ -249,6 +252,7 @@ fn parse_picture(
     let mut alt_text = None;
     let mut position = None;
     let mut embed_rid: Option<String> = None;
+    let mut hidden = false;
 
     loop {
         match reader.read_event()? {
@@ -258,6 +262,7 @@ fn parse_picture(
                     id = props.0;
                     name = props.1;
                     alt_text = props.2;
+                    hidden = props.3;
                 },
                 b"blipFill" => {
                     embed_rid = parse_blip_fill_embed(reader)?;
@@ -290,6 +295,7 @@ fn parse_picture(
         embed_rid,
         data,
         format,
+        hidden,
     }))
 }
 
@@ -541,11 +547,12 @@ fn parse_connector(reader: &mut quick_xml::Reader<&[u8]>) -> CoreResult<Shape> {
 /// ```
 fn parse_nv_common_props(
     reader: &mut quick_xml::Reader<&[u8]>,
-) -> CoreResult<(u32, String, Option<String>, Option<PlaceholderInfo>)> {
+) -> CoreResult<(u32, String, Option<String>, Option<PlaceholderInfo>, bool)> {
     let mut id = 0u32;
     let mut name = String::new();
     let mut alt_text = None;
     let mut placeholder = None;
+    let mut hidden = false;
 
     loop {
         match reader.read_event()? {
@@ -560,6 +567,7 @@ fn parse_nv_common_props(
                                 .map(|v| v.into_owned())
                                 .unwrap_or_default();
                             alt_text = xml::optional_attr_str(e, b"descr")?.map(|v| v.into_owned());
+                            hidden = attr_is_true(e, b"hidden")?;
                             xml::skip_element_fast(reader)?;
                         },
                         // p:nvPr contains p:ph — don't skip, keep parsing
@@ -579,6 +587,7 @@ fn parse_nv_common_props(
                         .map(|v| v.into_owned())
                         .unwrap_or_default();
                     alt_text = xml::optional_attr_str(e, b"descr")?.map(|v| v.into_owned());
+                    hidden = attr_is_true(e, b"hidden")?;
                 },
                 b"ph" => {
                     placeholder = Some(PlaceholderInfo {
@@ -596,16 +605,27 @@ fn parse_nv_common_props(
         }
     }
 
-    Ok((id, name, alt_text, placeholder))
+    Ok((id, name, alt_text, placeholder, hidden))
 }
 
-/// Parse `p:nvPicPr` → (id, name, alt_text)
+/// Read an OOXML boolean attribute (`xsd:boolean`: `1`/`true`/`on` = true),
+/// defaulting to `false` when the attribute is absent. Used for
+/// `<p:cNvPr hidden="…">`, where — unlike a toggle element — a missing
+/// attribute means "not hidden".
+fn attr_is_true(e: &quick_xml::events::BytesStart, name: &[u8]) -> CoreResult<bool> {
+    Ok(xml::optional_attr_str(e, name)?
+        .map(|v| matches!(v.as_ref(), "1" | "true" | "on"))
+        .unwrap_or(false))
+}
+
+/// Parse `p:nvPicPr` → (id, name, alt_text, hidden)
 fn parse_nv_pic_props(
     reader: &mut quick_xml::Reader<&[u8]>,
-) -> CoreResult<(u32, String, Option<String>)> {
+) -> CoreResult<(u32, String, Option<String>, bool)> {
     let mut id = 0u32;
     let mut name = String::new();
     let mut alt_text = None;
+    let mut hidden = false;
 
     loop {
         match reader.read_event()? {
@@ -617,6 +637,7 @@ fn parse_nv_pic_props(
                     .map(|v| v.into_owned())
                     .unwrap_or_default();
                 alt_text = xml::optional_attr_str(e, b"descr")?.map(|v| v.into_owned());
+                hidden = attr_is_true(e, b"hidden")?;
             },
             Event::End(ref e) if e.local_name().as_ref() == b"nvPicPr" => {
                 break;
@@ -626,7 +647,7 @@ fn parse_nv_pic_props(
         }
     }
 
-    Ok((id, name, alt_text))
+    Ok((id, name, alt_text, hidden))
 }
 
 /// Parse `p:nvGrpSpPr` → (id, name)

--- a/src/pptx/text.rs
+++ b/src/pptx/text.rs
@@ -463,6 +463,7 @@ mod tests {
                 }],
             }),
             placeholder: None,
+            hidden: false,
         })
     }
 
@@ -497,6 +498,7 @@ mod tests {
                 ph_type: Some("title".to_string()),
                 idx: Some(0),
             }),
+            hidden: false,
         })
     }
 
@@ -621,6 +623,7 @@ mod tests {
                     }],
                 }),
                 placeholder: None,
+                hidden: false,
             })],
             notes: None,
             background_rgb: None,
@@ -803,6 +806,7 @@ mod tests {
                     }],
                 }),
                 placeholder: None,
+                hidden: false,
             })],
             notes: None,
             background_rgb: None,


### PR DESCRIPTION
This series improves the fidelity of document conversion, focused on `.doc` (legacy Word binary) and `.pptx`. Each commit is self-contained; they apply on top of v0.1.7. No new external/runtime dependencies.

### What's included

**Embedded images in HTML output**
- `feat: emit embedded image bytes in HTML + wire .doc images into IR` — HTML output inlined `Image.data` as a base64 `data:` URI instead of an empty `<img>` (EMF/WMF stay empty, since most renderers can't display them); a small dependency-free base64 encoder is added. Also wires `.doc` images (the existing `DocDocument::images()` Data-stream BLIP extractor, whose output was never fed into the IR) into conversion. docx/pptx/xlsx already populate `Image.data`, so this makes their images appear too.
- `feat: position .doc images inline at their picture markers` — keep the `U+FFFC` picture placeholder in `piece_table` and split text on it, emitting `Element::Image` at each marker in document order (instead of appending images at the end). `plain_text()`/`to_markdown()` strip `U+FFFC` so text stays clean.
- `fix: wrap HTML images in their own <p> block` — a bare inline `<img>` gets folded into the preceding block by flow renderers (e.g. Qt's QTextBrowser), leaving large vertical gaps; wrapping it in `<p>…</p>` makes it a standalone block.

**`.doc` tables**
- `feat: reconstruct .doc tables from flattened text` — a cell mark and the row-terminating paragraph mark are both `0x07`, flattened to a tab, so a row ends in `"\t\t"` with single-tab-separated cells. Detect that and emit `Element::Table` (renders as a real `<table>`).
- `fix: don't absorb the sentence after a .doc table into the table` — a non-empty final segment after the row-end mark is the following paragraph, not a stray one-cell row; emit it as its own paragraph.

**Encryption detection**
- `feat: detect encrypted (password-protected) .doc files` — parse the `fEncrypted` FIB flag (bit 8 at offset `0x0A`) and return a dedicated `DocError::Encrypted`, so callers can report encrypted docs instead of producing garbage from still-encrypted streams. (Read-side *decryption* is a separate, larger change and is intentionally not part of this PR.)

**`.pptx`**
- `fix: skip hidden pptx shapes (cNvPr hidden="1") in preview` — a deck can carry off-slide fingerprint/watermark text boxes marked `<p:cNvPr … hidden="1">`; PowerPoint doesn't render them, but the converter extracted their text (leaking e.g. a long hex string into output). Parse the `hidden` attribute for auto-shapes and pictures and skip hidden shapes in `convert_shape()` and `find_title()`. Ordinary shapes are unaffected.

### Testing
- `cargo test --lib` — all 433 tests pass.
- Manually verified on real `.docx` and WPS-produced `.doc` files (images render inline under their headings; two 2-column tables render as bordered grids; the trailing sentence renders as a paragraph, not a cell) and on a `.pptx` whose hidden watermark text box no longer leaks into the output.

Happy to split this into smaller PRs if you'd prefer to review them separately.