### PR TITLE
fix(go): drop the version from the installer's asset filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -702,13 +702,17 @@ jobs:
         with:
           name: native-linux-x86_64
           path: release-assets
-      - name: Stage the native-linux-x86_64 archive where the installer expects it
+      - name: Stage the native-linux-x86_64 archive under its published name
         run: |
           set -euo pipefail
           VERSION="${{ needs.validate.outputs.version }}"
           mkdir -p /tmp/simulated-releases/v${VERSION}
+          # Serve the artifact under exactly the name create-release publishes.
+          # This step used to rename it to native-linux-x86_64-${VERSION}.tar.gz
+          # to match the URL the installer built, which meant the fixture agreed
+          # with the bug and the job passed against a filename no release has.
           cp release-assets/native-linux-x86_64.tar.gz \
-             /tmp/simulated-releases/v${VERSION}/native-linux-x86_64-${VERSION}.tar.gz
+             /tmp/simulated-releases/v${VERSION}/native-linux-x86_64.tar.gz
       - name: Serve the archive via a local HTTP server + patch the installer URL
         run: |
           set -euo pipefail

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -82,7 +82,11 @@ func main() {
 	if runtime.GOOS == "windows" {
 		ext = ".zip"
 	}
-	url := fmt.Sprintf("%s/v%s/%s-%s%s", releaseBase, version, tgt.assetBase, version, ext)
+	// The version appears in the tag directory only. Release assets are named
+	// `native-<os>-<arch>.<ext>` — tgt.assetBase is already the full published
+	// name, so interpolating the version into the filename too asks for an
+	// asset no release contains.
+	url := fmt.Sprintf("%s/v%s/%s%s", releaseBase, version, tgt.assetBase, ext)
 	fmt.Fprintf(os.Stderr, "Fetching %s\n", url)
 
 	body, err := httpGet(url)


### PR DESCRIPTION
Fixes #110.

`go run github.com/yfedoseev/office_oxide/go/cmd/install@latest` currently 404s on every platform and every release. The download URL interpolates the version twice — once as the tag directory (correct) and once into the filename (not): assets are published as `native-<os>-<arch>.<ext>`, and `tgt.assetBase` already holds that full name.

```diff
-	url := fmt.Sprintf("%s/v%s/%s-%s%s", releaseBase, version, tgt.assetBase, version, ext)
+	url := fmt.Sprintf("%s/v%s/%s%s", releaseBase, version, tgt.assetBase, ext)
```

Verified against the v0.1.8 assets using the installer's own `defaultVersion` — all six URLs it builds are 404, all six published names are 200:

| requested by installer | published |
| --- | --- |
| `native-linux-x86_64-0.1.8.tar.gz` → **404** | `native-linux-x86_64.tar.gz` → 200 |
| `native-linux-aarch64-0.1.8.tar.gz` → **404** | `native-linux-aarch64.tar.gz` → 200 |
| `native-macos-x86_64-0.1.8.tar.gz` → **404** | `native-macos-x86_64.tar.gz` → 200 |
| `native-macos-aarch64-0.1.8.tar.gz` → **404** | `native-macos-aarch64.tar.gz` → 200 |
| `native-windows-x86_64-0.1.8.zip` → **404** | `native-windows-x86_64.zip` → 200 |
| `native-windows-aarch64-0.1.8.zip` → **404** | `native-windows-aarch64.zip` → 200 |

### The second change is the one that matters longer-term

`verify-go-install` *does* run the installer, so it is fair to ask why this was never caught. The staging step renamed the built artifact to the name the installer expected before serving it:

```bash
cp release-assets/native-linux-x86_64.tar.gz \
   /tmp/simulated-releases/v${VERSION}/native-linux-x86_64-${VERSION}.tar.gz
```

The fixture agreed with the bug, so the job passed against a filename no release has ever contained. It now serves the artifact under its published name — which is what makes the installer and `create-release` drifting apart visible again in future.

### Alternative

Changing `release.yml` to publish `native-<os>-<arch>-<version>.<ext>` instead would fix it equally well, and is the better call if anything outside this repo already depends on the versioned names. Happy to redo it that way — I picked the installer side because it needs no change to what consumers download.

### Notes

- No functional change beyond the URL; the extract/verify path is untouched.
- Found while running this code in a downstream fork. Thanks for office_oxide — it has been a pleasure to build on.
