### PR TITLE
fix(lint): rewrite constant-size chunks_exact as as_chunks

### DIFF
--- a/src/cfb/reader.rs
+++ b/src/cfb/reader.rs
@@ -39,10 +39,8 @@ impl<R: Read + Seek> CfbReader<R> {
         let mini_fat = if header.first_mini_fat_sector <= MAX_REG_SECT {
             let mini_fat_data =
                 Self::read_chain(&mut reader, &header, &fat, header.first_mini_fat_sector)?;
-            mini_fat_data
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect()
+            let (quads, _rest) = mini_fat_data.as_chunks::<4>();
+            quads.iter().copied().map(u32::from_le_bytes).collect()
         } else {
             Vec::new()
         };

--- a/src/ppt/text.rs
+++ b/src/ppt/text.rs
@@ -375,10 +375,8 @@ pub struct SlideText {
 }
 
 fn decode_utf16le(data: &[u8]) -> String {
-    let chars: Vec<u16> = data
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .collect();
+    let (pairs, _rest) = data.as_chunks::<2>();
+    let chars: Vec<u16> = pairs.iter().copied().map(u16::from_le_bytes).collect();
     String::from_utf16_lossy(&chars)
 }
 


### PR DESCRIPTION
## Why every PR is red on Clippy

Rust 1.98's clippy added [`chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks). Two call sites in the tree trigger it, and both the `Clippy` job and the `Lint and Format Check` job run with `-D warnings`, so this fails on `main` itself:

```
error: using `chunks_exact` with a constant chunk size
  --> src/cfb/reader.rs:43:18
error: using `chunks_exact` with a constant chunk size
   --> src/ppt/text.rs:379:10
error: could not compile `office_oxide` (lib) due to 2 previous errors
```

No PR introduced this — the toolchain moved under a gate that treats warnings as errors.

## The change

`as_chunks::<N>()` returns the complete chunks plus the remainder; discarding the remainder is precisely what `chunks_exact` did, so behaviour is identical. It also hands `from_le_bytes` a `[u8; N]` directly instead of rebuilding one element by element.

## Verification

```
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo +1.88 build --lib -p office_oxide     # the MSRV job's exact command
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

`as_chunks` stabilised in Rust **1.88**, which is exactly this workspace's declared `rust-version`, so the MSRV job is unaffected — I installed 1.88 and checked rather than assuming. `cargo fmt` clean; full test suite green (10 suites, 0 failures).

## Together with #123

#123 clears the 31 `ruff` findings in the same `Lint and Format Check` job. That job runs `cargo fmt` → `cargo clippy -D warnings` → `ruff`, and it was failing at the **clippy** step before ever reaching ruff, so **both** PRs are needed to turn the 11 open dependabot PRs green: #101, #105, #106, #107, #108, #109, #112, #113, #114, #117, #121.

https://claude.ai/code/session_01QCzrWMwEUtN6B3pN1HSKbb