### PR TITLE
feat(doc): derive heading levels from the style sheet (STSH)

### DIFF
--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -391,7 +391,7 @@ fn walk_paragraphs(paragraphs: &[DocParagraph], elements: &mut Vec<Element>) {
         } else {
             table.flush(elements);
             flush_list(&mut list_items, elements);
-            emit_prose(&p.text, &p.props.tabs, elements);
+            emit_prose(&p.text, &p.props.tabs, p.props.heading_level, elements);
         }
     }
     table.flush(elements);
@@ -442,11 +442,38 @@ fn inline_content_for(text: &str) -> Vec<InlineContent> {
 
 /// Classify a prose paragraph as a heading or paragraph and push it.
 ///
-/// Mirrors the line-based heuristic so a PAPX-bearing document keeps the same
-/// heading/title detection as the fallback path.
-fn emit_prose(text: &str, tabs: &[TabStop], elements: &mut Vec<Element>) {
+/// When `heading_level` is `Some`, the paragraph is a styled heading and its
+/// real level is used directly (resolved from `sprmPOutlineLvl` or the
+/// paragraph's style in the document style sheet — see `crate::doc::styles`).
+/// Otherwise the line-based heuristic is applied, keeping a PAPX-bearing
+/// document's heading/title detection identical to the fallback path.
+fn emit_prose(
+    text: &str,
+    tabs: &[TabStop],
+    heading_level: Option<u8>,
+    elements: &mut Vec<Element>,
+) {
     let trimmed = text.trim();
     if trimmed.is_empty() {
+        return;
+    }
+
+    // A styled heading uses its real level, overriding the heuristic.
+    if let Some(level) = heading_level {
+        let mut content = inline_content_for(trimmed);
+        for ic in &mut content {
+            if let InlineContent::Text(t) = ic {
+                t.bold = true;
+            }
+        }
+        elements.push(Element::Heading(Heading {
+            // MS-DOC outline levels are 1-based and run to 9, but
+            // `Heading::level` is a 1–6 markdown-style depth; clamp, matching
+            // the DOCX path's `(outline_level + 1).min(6)`.
+            level: level.min(6),
+            content,
+            ..Default::default()
+        }));
         return;
     }
 
@@ -488,7 +515,7 @@ fn emit_prose(text: &str, tabs: &[TabStop], elements: &mut Vec<Element>) {
 
 fn line_heuristic(text: &str, elements: &mut Vec<Element>) {
     for line in text.lines() {
-        emit_prose(line, &[], elements);
+        emit_prose(line, &[], None, elements);
     }
 }
 

--- a/src/convert_doc.rs
+++ b/src/convert_doc.rs
@@ -22,7 +22,19 @@ pub(crate) fn doc_to_ir(doc: &DocDocument) -> DocumentIR {
     // styles would silently lose their headings, and with them
     // `metadata.title` and `Section.title`, both of which are derived from
     // the first `Element::Heading` below.
-    let has_structured_headings = paragraphs.iter().any(|p| p.props.outline_level.is_some());
+    //
+    // Gated on a level the document states *explicitly* (`sprmPOutLvl`), not
+    // merely one we resolved from a style. A couple of styled paragraphs are
+    // not evidence that the document's headings are structured: real
+    // documents style a few headings and leave the rest as plain ALL-CAPS
+    // lines, and gating on those collapsed `parentinvguid.doc` from 35
+    // headings to 2 — the 33 unstyled section headings stopped being
+    // recognised altogether. Style-derived levels still give the paragraphs
+    // that carry them their real level; they just do not switch the guess off
+    // for their neighbours.
+    let has_structured_headings = paragraphs
+        .iter()
+        .any(|p| p.props.outline_lvl_explicit && p.props.outline_level.is_some());
     if !paragraphs.is_empty() {
         walk_paragraphs(paragraphs, has_structured_headings, &mut elements);
     } else {
@@ -526,7 +538,7 @@ fn emit_heading(text: &str, level: u8, elements: &mut Vec<Element>) {
         }
     }
     elements.push(Element::Heading(Heading {
-        level: level.clamp(1, 6),
+        level: level.clamp(1, MAX_HEADING_DEPTH),
         content,
         ..Default::default()
     }));
@@ -825,6 +837,142 @@ mod tests {
         assert!(
             els.iter().any(|e| matches!(e, Element::Table(_))),
             "f_in_table cell paragraph must be emitted inside a table"
+        );
+    }
+
+    /// A paragraph inside a table whose style resolves to a heading must stay a
+    /// table cell. `walk_paragraphs` routes table paragraphs before `emit_prose`,
+    /// so a styled heading can neither leak into the table structure nor escape
+    /// it as a top-level `Heading`.
+    ///
+    /// Note this guards the *routing* (pre-existing) as well as the styled
+    /// heading branch: without the final contrast below it would pass even with
+    /// the branch deleted, which is how it was first (wrongly) revert-checked.
+    #[test]
+    fn styled_heading_inside_table_stays_a_cell() {
+        let mark = DocParagraph {
+            text: String::new(),
+            terminator: '\r',
+            props: PapProps {
+                is_table_trailing_mark: true,
+                itap: 1,
+                outline_level: Some(2),
+                ..PapProps::default()
+            },
+        };
+        let cell = DocParagraph {
+            text: "cell text".into(),
+            terminator: '\u{7}', // closes the cell
+            props: PapProps {
+                f_in_table: true,
+                outline_level: Some(2),
+                ..PapProps::default()
+            },
+        };
+        let paragraphs = [mark.clone(), cell.clone(), mark];
+        let mut els = Vec::new();
+        walk_paragraphs(&paragraphs, true, &mut els);
+        assert!(
+            els.iter().any(|e| matches!(e, Element::Table(_))),
+            "the cell must still be emitted inside a table"
+        );
+        assert!(
+            !els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "a styled heading inside a table must not become a Heading"
+        );
+
+        // Contrast, so the assertions above cannot pass merely because the
+        // level is ignored: the same paragraph outside a table must produce a
+        // Heading. It carries `outline_level`, so `emit_heading` handles it
+        // whatever the text looks like — what the contrast pins is the table
+        // routing above, not the line-shape guess.
+        let mut prose = cell;
+        prose.props.f_in_table = false;
+        prose.terminator = '\r';
+        prose.text = "cell text.".into();
+        let mut els = Vec::new();
+        walk_paragraphs(&[prose], true, &mut els);
+        assert!(
+            els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "outside a table the same styled paragraph must emit a Heading"
+        );
+    }
+
+    /// A row-terminator paragraph that also carries a heading style must end the
+    /// row, not emit a `Heading` into the element stream.
+    #[test]
+    fn styled_heading_on_row_terminator_is_not_a_heading() {
+        let row = DocParagraph {
+            // A row terminator can carry the trailing cell's text; keeping it
+            // non-empty is what makes this test meaningful — an empty text
+            // would be dropped by `emit_prose` whether or not the routing is
+            // correct, so the test could not tell the two apart.
+            text: "row text.".into(),
+            terminator: '\r',
+            props: PapProps {
+                is_table_trailing_mark: true,
+                itap: 1,
+                outline_level: Some(1),
+                ..PapProps::default()
+            },
+        };
+        let mut els = Vec::new();
+        walk_paragraphs(std::slice::from_ref(&row), true, &mut els);
+        assert!(
+            !els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "a row-terminator paragraph must end a row, not emit a Heading"
+        );
+        // Contrast: the same paragraph as ordinary prose must emit a Heading.
+        // It carries `outline_level`, so this pins that being a row terminator
+        // — not the text shape — is what suppressed the heading above.
+        let mut prose = row;
+        prose.props.is_table_trailing_mark = false;
+        let mut els = Vec::new();
+        walk_paragraphs(&[prose], true, &mut els);
+        assert!(
+            els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "as ordinary prose the same paragraph must emit a Heading"
+        );
+    }
+
+    /// A paragraph that is a list member and whose style resolves to a heading
+    /// stays a list item: `walk_paragraphs` routes list membership (keyed on
+    /// `ilfo`) before `emit_prose`. Like the table case this pins the routing;
+    /// the positive coverage for the styled-heading branch itself lives in
+    /// `doc::document` (`synthetic_doc_styled_heading_uses_style_sheet_level`).
+    #[test]
+    fn styled_heading_list_item_stays_a_list_item() {
+        let item = DocParagraph {
+            text: "item".into(),
+            terminator: '\r',
+            props: PapProps {
+                ilfo: Some(1),
+                ilvl: Some(0),
+                outline_level: Some(3),
+                ..PapProps::default()
+            },
+        };
+        let mut els = Vec::new();
+        walk_paragraphs(std::slice::from_ref(&item), true, &mut els);
+        assert!(
+            els.iter().any(|e| matches!(e, Element::List(_))),
+            "a list member must be emitted as a List"
+        );
+        assert!(
+            !els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "a styled heading that is a list item must not become a Heading"
+        );
+        // Contrast: outside a list the same paragraph must emit a Heading. It
+        // carries `outline_level`, so this pins that list membership — not the
+        // text shape — is what suppressed the heading above.
+        let mut prose = item;
+        prose.props.ilfo = None;
+        prose.text = "item.".into();
+        let mut els = Vec::new();
+        walk_paragraphs(&[prose], true, &mut els);
+        assert!(
+            els.iter().any(|e| matches!(e, Element::Heading(_))),
+            "outside a list the same styled paragraph must emit a Heading"
         );
     }
 

--- a/src/doc/document.rs
+++ b/src/doc/document.rs
@@ -9,6 +9,7 @@ use super::fib::Fib;
 use super::images::{DocImage, extract_images};
 use super::papx::{DocParagraph, build_paragraphs, parse_papx_paragraphs};
 use super::piece_table::{extract_text, parse_clx, sanitize_text};
+use super::styles::{StyleDef, parse_style_sheet};
 
 /// A parsed legacy Word document.
 #[derive(Debug)]
@@ -105,7 +106,12 @@ impl DocDocument {
                 fib.fc_plcf_bte_papx,
                 fib.lcb_plcf_bte_papx,
             );
-            build_paragraphs(&word_doc, &pieces, &fkp, fib.text_len)
+            // Parse the style sheet so paragraph styles (incl. built-in
+            // Heading 1-9 and user-defined "Heading N") can be resolved to a
+            // real heading level. A malformed/absent sheet yields an empty
+            // list and headings fall back to the line heuristic.
+            let styles: Vec<StyleDef> = parse_style_sheet(&table_stream, &fib);
+            build_paragraphs(&word_doc, &pieces, &fkp, fib.text_len, &styles)
         } else {
             Vec::new()
         };
@@ -329,6 +335,55 @@ mod tests {
         use crate::ir::Element;
         let ir = crate::convert_doc::doc_to_ir(&make_doc("Title\nSECTION TWO\nBody text."));
         assert!(matches!(ir.sections[0].elements[1], Element::Heading(ref h) if h.level == 2));
+    }
+
+    #[test]
+    fn ir_styled_heading_uses_real_level() {
+        use crate::ir::Element;
+        // A styled "Heading 3" paragraph that is NOT the first element must
+        // keep its real level (3) instead of collapsing to the heuristic level
+        // 2 (the `elements.is_empty() ? 1 : 2` rule in `emit_prose`). This is
+        // the regression test for deriving heading levels from paragraph style
+        // rather than the line heuristic.
+        let doc = make_doc_with_paragraphs(vec![
+            pap("Intro paragraph.", Default::default()),
+            pap(
+                "Subsection",
+                crate::doc::sprm::PapProps {
+                    heading_level: Some(3),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+        let elements = &ir.sections[0].elements;
+        assert!(matches!(elements[0], Element::Paragraph(_)));
+        match &elements[1] {
+            Element::Heading(h) => {
+                assert_eq!(h.level, 3, "styled heading must keep its real level")
+            },
+            other => panic!("expected a Heading, got {:?}", other),
+        }
+    }
+
+    /// Regression: MS-DOC outline levels run 1–9 but `Heading::level` is a
+    /// 1–6 markdown depth, so a deeply-nested heading must clamp to 6 rather
+    /// than emitting an out-of-contract level.
+    #[test]
+    fn ir_deep_outline_level_clamps_to_six() {
+        use crate::ir::Element;
+        let doc = make_doc_with_paragraphs(vec![pap(
+            "Deep section",
+            crate::doc::sprm::PapProps {
+                heading_level: Some(9),
+                ..Default::default()
+            },
+        )]);
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+        match &ir.sections[0].elements[0] {
+            Element::Heading(h) => assert_eq!(h.level, 6, "outline level 9 must clamp to 6"),
+            other => panic!("expected a Heading, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/doc/document.rs
+++ b/src/doc/document.rs
@@ -9,6 +9,7 @@ use super::fib::Fib;
 use super::images::{DocImage, extract_images};
 use super::papx::{DocParagraph, build_paragraphs, parse_papx_paragraphs};
 use super::piece_table::{extract_text, parse_clx, sanitize_text};
+use super::styles::{StyleDef, parse_style_sheet};
 
 /// A parsed legacy Word document.
 #[derive(Debug)]
@@ -141,7 +142,12 @@ impl DocDocument {
                 fib.fc_plcf_bte_papx,
                 fib.lcb_plcf_bte_papx,
             );
-            build_paragraphs(&word_doc, &pieces, &fkp, fib.text_len)
+            // Parse the style sheet so paragraph styles (incl. built-in
+            // Heading 1-9 and user-defined "Heading N") can be resolved to a
+            // real heading level. A malformed/absent sheet yields an empty
+            // list and headings fall back to the line heuristic.
+            let styles: Vec<StyleDef> = parse_style_sheet(&table_stream, &fib);
+            build_paragraphs(&word_doc, &pieces, &fkp, fib.text_len, &styles)
         } else {
             Vec::new()
         };
@@ -379,6 +385,61 @@ mod tests {
     }
 
     #[test]
+    fn ir_styled_heading_uses_real_level() {
+        use crate::ir::Element;
+        // A styled "Heading 3" paragraph that is NOT the first element must
+        // keep its real level (3) instead of collapsing to the heuristic level
+        // 2 (the `elements.is_empty() ? 1 : 2` rule in `emit_prose`). This is
+        // the regression test for deriving heading levels from paragraph style
+        // rather than the line heuristic.
+        let doc = make_doc_with_paragraphs(vec![
+            pap("Intro paragraph.", Default::default()),
+            pap(
+                "Subsection",
+                crate::doc::sprm::PapProps {
+                    outline_level: Some(2),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+        let elements = &ir.sections[0].elements;
+        assert!(matches!(elements[0], Element::Paragraph(_)));
+        match &elements[1] {
+            Element::Heading(h) => {
+                assert_eq!(h.level, 3, "styled heading must keep its real level")
+            },
+            other => panic!("expected a Heading, got {:?}", other),
+        }
+    }
+
+    /// Regression: MS-DOC outline levels run to `MAX_OUTLINE_LEVEL` but
+    /// `Heading::level` is a 1..=MAX_HEADING_DEPTH markdown depth, so a
+    /// deeply-nested heading must clamp at the IR boundary rather than emitting
+    /// an out-of-contract level.
+    #[test]
+    fn ir_deep_outline_level_clamps_to_ir_max_depth() {
+        use crate::doc::MAX_OUTLINE_LEVEL;
+        use crate::ir::Element;
+        use crate::ir::MAX_HEADING_DEPTH;
+        let doc = make_doc_with_paragraphs(vec![pap(
+            "Deep section",
+            crate::doc::sprm::PapProps {
+                outline_level: Some(MAX_OUTLINE_LEVEL - 1),
+                ..Default::default()
+            },
+        )]);
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+        match &ir.sections[0].elements[0] {
+            Element::Heading(h) => assert_eq!(
+                h.level, MAX_HEADING_DEPTH,
+                "outline level {MAX_OUTLINE_LEVEL} must clamp to {MAX_HEADING_DEPTH}"
+            ),
+            other => panic!("expected a Heading, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn ir_line_ending_with_period_becomes_paragraph() {
         use crate::ir::Element;
         let ir = crate::convert_doc::doc_to_ir(&make_doc("This is a sentence."));
@@ -417,5 +478,490 @@ mod tests {
     fn ir_format_is_doc() {
         let ir = crate::convert_doc::doc_to_ir(&make_doc("content"));
         assert_eq!(ir.metadata.format, crate::format::DocumentFormat::Doc);
+    }
+
+    // --------------------------------------------------------------------
+    // End-to-end regression for the style-sheet heading path (PR #127).
+    //
+    // Every real `.doc` in the POI / Tika / LibreOffice corpora reports
+    // `fc_stshf == 0` (no style sheet), so the new path that resolves a
+    // heading's *real* level from the paragraph style (see `build_paragraphs`
+    // → `heading_level_for_istd`) is never exercised by a corpus run. This test
+    // synthesises a complete CFB `.doc` in code — per AGENTS.md #4 no
+    // third-party fixture is committed — whose `1Table` carries a style sheet
+    // mapping a paragraph's `istd` to built-in `Heading 3`, and asserts the IR
+    // heading keeps level 3. The line heuristic tops out at level 2, so a
+    // level-3 heading can ONLY come from the style sheet: the output
+    // simultaneously proves the path fires and that it is not silently
+    // collapsing to the heuristic level.
+    // --------------------------------------------------------------------
+
+    // CFB v3 sector sentinels (mirror `cfb::header`).
+    const CFB_EOC: u32 = 0xFFFF_FFFE;
+    const CFB_FREE: u32 = 0xFFFF_FFFF;
+    const CFB_FATSECT: u32 = 0xFFFF_FFFD;
+
+    /// Build a complete, minimal CFB `.doc` driving the style-sheet heading
+    /// path end to end: an "Introduction." body paragraph (Normal style)
+    /// followed by a "Subsection Three" paragraph styled `Heading 3`. The bytes
+    /// are synthesised here, not read from any document file.
+    /// `body` is the first (Normal-styled) paragraph's text; the second is
+    /// always the `Heading 3` one. Parameterised so tests can make the body
+    /// line one the line-shape heuristic would have guessed on its own.
+    fn build_synthetic_styled_doc(body: &str) -> Vec<u8> {
+        const SECTOR: usize = 512;
+        const WORD_DOC_SECTORS: usize = 4; // 2048 bytes
+        const TABLE_SECTORS: usize = 2; // 1024 bytes
+        const TOTAL_SECTORS: usize = 1 + 1 + WORD_DOC_SECTORS + TABLE_SECTORS;
+
+        let mut file = vec![0u8; SECTOR + TOTAL_SECTORS * SECTOR];
+
+        // ── Header ──
+        file[0..8].copy_from_slice(&[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        file[0x18..0x1A].copy_from_slice(&0x003Eu16.to_le_bytes());
+        file[0x1A..0x1C].copy_from_slice(&3u16.to_le_bytes());
+        file[0x1C..0x1E].copy_from_slice(&0xFFFEu16.to_le_bytes());
+        file[0x1E..0x20].copy_from_slice(&9u16.to_le_bytes());
+        file[0x20..0x22].copy_from_slice(&6u16.to_le_bytes());
+        file[0x2C..0x30].copy_from_slice(&1u32.to_le_bytes()); // FAT count = 1
+        file[0x30..0x34].copy_from_slice(&0u32.to_le_bytes()); // first dir = 0
+        file[0x38..0x3C].copy_from_slice(&4096u32.to_le_bytes()); // mini cutoff
+        file[0x3C..0x40].copy_from_slice(&CFB_EOC.to_le_bytes()); // no mini-FAT
+        file[0x40..0x44].copy_from_slice(&0u32.to_le_bytes());
+        file[0x44..0x48].copy_from_slice(&CFB_EOC.to_le_bytes()); // no DIFAT chain
+        file[0x48..0x4C].copy_from_slice(&0u32.to_le_bytes());
+        file[0x4C..0x50].copy_from_slice(&1u32.to_le_bytes()); // DIFAT[0] = FAT sector 1
+        for i in 1..109 {
+            let off = 0x4C + i * 4;
+            file[off..off + 4].copy_from_slice(&CFB_FREE.to_le_bytes());
+        }
+
+        // ── Directory (sector 0): Root Entry -> {WordDocument, 1Table} ──
+        let dir = SECTOR;
+        write_dir_entry(&mut file[dir..dir + 128], "Root Entry", 5, 1, CFB_EOC, 0);
+        write_dir_entry(
+            &mut file[dir + 128..dir + 256],
+            "WordDocument",
+            2,
+            CFB_FREE,
+            2,
+            (WORD_DOC_SECTORS * SECTOR) as u32,
+        );
+        write_dir_entry(
+            &mut file[dir + 256..dir + 384],
+            "1Table",
+            2,
+            CFB_FREE,
+            6,
+            (TABLE_SECTORS * SECTOR) as u32,
+        );
+        // Entry 3: empty (type 0) — fills out the 512-byte directory sector.
+
+        // ── FAT (sector 1) ──
+        let fat = SECTOR + SECTOR; // byte offset 1024
+        let mut fat_entry = |idx: usize, val: u32| {
+            let off = fat + idx * 4;
+            file[off..off + 4].copy_from_slice(&val.to_le_bytes());
+        };
+        fat_entry(0, CFB_EOC); // directory, single sector
+        fat_entry(1, CFB_FATSECT); // this sector is a FAT sector
+        fat_entry(2, 3); // WordDocument chain: 2 -> 3 -> 4 -> 5 -> EOC
+        fat_entry(3, 4);
+        fat_entry(4, 5);
+        fat_entry(5, CFB_EOC);
+        fat_entry(6, 7); // 1Table chain: 6 -> 7 -> EOC
+        fat_entry(7, CFB_EOC);
+        for i in 8..128 {
+            fat_entry(i, CFB_FREE);
+        }
+
+        // ── WordDocument stream (sectors 2..5) ──
+        let wd_off = SECTOR + 2 * SECTOR; // byte offset 1536
+        let mut wd = vec![0u8; WORD_DOC_SECTORS * SECTOR];
+
+        // FIB.
+        wd[0..2].copy_from_slice(&0xA5ECu16.to_le_bytes()); // wIdent (Word 97+)
+        wd[2..4].copy_from_slice(&0x00C1u16.to_le_bytes()); // nFib
+        wd[0x0A..0x0C].copy_from_slice(&(1u16 << 9).to_le_bytes()); // flags: use 1Table
+
+        let body_para = format!("{body}\r");
+        let raw = format!("{body_para}Subsection Three\r");
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let ccp = (text_bytes.len() / 2) as u32; // main-text character count
+        wd[0x4C..0x50].copy_from_slice(&ccp.to_le_bytes()); // ccpText
+
+        let clx = build_clx(ccp);
+        let stsh = build_stsh_heading3();
+        wd[0xA2..0xA6].copy_from_slice(&288u32.to_le_bytes()); // fcStshf = 0x120
+        wd[0xA6..0xAA].copy_from_slice(&(stsh.len() as u32).to_le_bytes()); // lcbStshf
+        wd[0x102..0x106].copy_from_slice(&256u32.to_le_bytes()); // fcPlcfBtePapx
+        wd[0x106..0x10A].copy_from_slice(&12u32.to_le_bytes()); // lcbPlcfBtePapx
+        wd[0x1A2..0x1A6].copy_from_slice(&0u32.to_le_bytes()); // fcClx
+        wd[0x1A6..0x1AA].copy_from_slice(&(clx.len() as u32).to_le_bytes()); // lcbClx
+
+        // Document text at fc 0x300 (Unicode).
+        wd[0x300..0x300 + text_bytes.len()].copy_from_slice(&text_bytes);
+
+        // PAPX FKP page at page number 2 (byte offset 0x400). Two paragraphs:
+        // a Normal body paragraph and a Heading-3 paragraph.
+        let para0_end_fc = 0x300 + (format!("{body}\r").encode_utf16().count() * 2) as u32;
+        let para1_end_fc = 0x300 + (raw.encode_utf16().count() * 2) as u32;
+        wd[0x400..0x404].copy_from_slice(&0x300u32.to_le_bytes()); // rgfc[0]
+        wd[0x404..0x408].copy_from_slice(&para0_end_fc.to_le_bytes()); // rgfc[1]
+        wd[0x408..0x40C].copy_from_slice(&para1_end_fc.to_le_bytes()); // rgfc[2]
+        // rgbx: byte 0 of each BX is the word offset of that paragraph's PAPX.
+        wd[0x40C] = 19; // para0 PAPX at byte 38 (word 19)
+        wd[0x419] = 21; // para1 PAPX at byte 42 (word 21)
+        // para0 PAPX: cw=2, istd=0 (Normal), empty grpprl.
+        wd[0x426] = 0x02; // cw
+        // 0x427..0x429 = istd 0x0000, 0x429 = grpprl (0x00)
+        // para1 PAPX: cw=2, istd=3 (Heading 3), empty grpprl.
+        wd[0x42A] = 0x02; // cw
+        wd[0x42B..0x42D].copy_from_slice(&0x0003u16.to_le_bytes()); // istd = 3
+        // 0x42D = grpprl (0x00)
+        wd[0x5FF] = 2; // crun = 2
+
+        file[wd_off..wd_off + wd.len()].copy_from_slice(&wd);
+
+        // ── 1Table stream (sectors 6..7) ──
+        let tbl_off = SECTOR + 6 * SECTOR; // byte offset 3584
+        let mut tbl = vec![0u8; TABLE_SECTORS * SECTOR];
+        tbl[0..clx.len()].copy_from_slice(&clx); // CLX at offset 0
+        // PlcfBtePapx at 0x100: n=1 -> [FC0=0][FC1=ccp][BTE=pn 2].
+        tbl[0x100..0x104].copy_from_slice(&0u32.to_le_bytes());
+        tbl[0x104..0x108].copy_from_slice(&ccp.to_le_bytes());
+        tbl[0x108..0x10C].copy_from_slice(&2u32.to_le_bytes());
+        // STSH at 0x120 (0x300 would overflow the 2-sector table stream).
+        tbl[0x120..0x120 + stsh.len()].copy_from_slice(&stsh);
+
+        file[tbl_off..tbl_off + tbl.len()].copy_from_slice(&tbl);
+
+        file
+    }
+
+    /// Like `build_synthetic_styled_doc`, but paragraph 1 carries
+    /// `sprmPOutLvl` (0x2640) in its PAPX grpprl (Heading 5) instead of
+    /// relying on a style. Its PAPX `istd` is 0 (Normal), so the Heading level
+    /// comes solely from the outline SPRM — exercising the SPRM path end to end
+    /// (CFB → FKP → `build_paragraphs` → `doc_to_ir`).
+    fn build_synthetic_outline_doc() -> Vec<u8> {
+        const SECTOR: usize = 512;
+        const WORD_DOC_SECTORS: usize = 4; // 2048 bytes
+        const TABLE_SECTORS: usize = 2; // 1024 bytes
+        const TOTAL_SECTORS: usize = 1 + 1 + WORD_DOC_SECTORS + TABLE_SECTORS;
+
+        let mut file = vec![0u8; SECTOR + TOTAL_SECTORS * SECTOR];
+
+        // ── Header ──
+        file[0..8].copy_from_slice(&[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        file[0x18..0x1A].copy_from_slice(&0x003Eu16.to_le_bytes());
+        file[0x1A..0x1C].copy_from_slice(&3u16.to_le_bytes());
+        file[0x1C..0x1E].copy_from_slice(&0xFFFEu16.to_le_bytes());
+        file[0x1E..0x20].copy_from_slice(&9u16.to_le_bytes());
+        file[0x20..0x22].copy_from_slice(&6u16.to_le_bytes());
+        file[0x2C..0x30].copy_from_slice(&1u32.to_le_bytes()); // FAT count = 1
+        file[0x30..0x34].copy_from_slice(&0u32.to_le_bytes()); // first dir = 0
+        file[0x38..0x3C].copy_from_slice(&4096u32.to_le_bytes()); // mini cutoff
+        file[0x3C..0x40].copy_from_slice(&CFB_EOC.to_le_bytes()); // no mini-FAT
+        file[0x40..0x44].copy_from_slice(&0u32.to_le_bytes());
+        file[0x44..0x48].copy_from_slice(&CFB_EOC.to_le_bytes()); // no DIFAT chain
+        file[0x48..0x4C].copy_from_slice(&0u32.to_le_bytes());
+        file[0x4C..0x50].copy_from_slice(&1u32.to_le_bytes()); // DIFAT[0] = FAT sector 1
+        for i in 1..109 {
+            let off = 0x4C + i * 4;
+            file[off..off + 4].copy_from_slice(&CFB_FREE.to_le_bytes());
+        }
+
+        // ── Directory (sector 0): Root Entry -> {WordDocument, 1Table} ──
+        let dir = SECTOR;
+        write_dir_entry(&mut file[dir..dir + 128], "Root Entry", 5, 1, CFB_EOC, 0);
+        write_dir_entry(
+            &mut file[dir + 128..dir + 256],
+            "WordDocument",
+            2,
+            CFB_FREE,
+            2,
+            (WORD_DOC_SECTORS * SECTOR) as u32,
+        );
+        write_dir_entry(
+            &mut file[dir + 256..dir + 384],
+            "1Table",
+            2,
+            CFB_FREE,
+            6,
+            (TABLE_SECTORS * SECTOR) as u32,
+        );
+
+        // ── FAT (sector 1) ──
+        let fat = SECTOR + SECTOR; // byte offset 1024
+        let mut fat_entry = |idx: usize, val: u32| {
+            let off = fat + idx * 4;
+            file[off..off + 4].copy_from_slice(&val.to_le_bytes());
+        };
+        fat_entry(0, CFB_EOC); // directory, single sector
+        fat_entry(1, CFB_FATSECT); // this sector is a FAT sector
+        fat_entry(2, 3); // WordDocument chain: 2 -> 3 -> 4 -> 5 -> EOC
+        fat_entry(3, 4);
+        fat_entry(4, 5);
+        fat_entry(5, CFB_EOC);
+        fat_entry(6, 7); // 1Table chain: 6 -> 7 -> EOC
+        fat_entry(7, CFB_EOC);
+        for i in 8..128 {
+            fat_entry(i, CFB_FREE);
+        }
+
+        // ── WordDocument stream (sectors 2..5) ──
+        let wd_off = SECTOR + 2 * SECTOR; // byte offset 1536
+        let mut wd = vec![0u8; WORD_DOC_SECTORS * SECTOR];
+
+        // FIB.
+        wd[0..2].copy_from_slice(&0xA5ECu16.to_le_bytes()); // wIdent (Word 97+)
+        wd[2..4].copy_from_slice(&0x00C1u16.to_le_bytes()); // nFib
+        wd[0x0A..0x0C].copy_from_slice(&(1u16 << 9).to_le_bytes()); // flags: use 1Table
+
+        let raw = "Introduction.\rSubsection Three\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let ccp = (text_bytes.len() / 2) as u32; // main-text character count
+        wd[0x4C..0x50].copy_from_slice(&ccp.to_le_bytes()); // ccpText
+
+        let clx = build_clx(ccp);
+        let stsh = build_stsh_heading3();
+        wd[0xA2..0xA6].copy_from_slice(&288u32.to_le_bytes()); // fcStshf = 0x120
+        wd[0xA6..0xAA].copy_from_slice(&(stsh.len() as u32).to_le_bytes()); // lcbStshf
+        wd[0x102..0x106].copy_from_slice(&256u32.to_le_bytes()); // fcPlcfBtePapx
+        wd[0x106..0x10A].copy_from_slice(&12u32.to_le_bytes()); // lcbPlcfBtePapx
+        wd[0x1A2..0x1A6].copy_from_slice(&0u32.to_le_bytes()); // fcClx
+        wd[0x1A6..0x1AA].copy_from_slice(&(clx.len() as u32).to_le_bytes()); // lcbClx
+
+        // Document text at fc 0x300 (Unicode).
+        wd[0x300..0x300 + text_bytes.len()].copy_from_slice(&text_bytes);
+
+        // PAPX FKP page at page number 2 (byte offset 0x400). Two paragraphs:
+        // a Normal body paragraph and an outline-SPRM Heading-5 paragraph.
+        let para0_end_fc = 0x300 + ("Introduction.\r".encode_utf16().count() * 2) as u32;
+        let para1_end_fc = 0x300 + (raw.encode_utf16().count() * 2) as u32;
+        wd[0x400..0x404].copy_from_slice(&0x300u32.to_le_bytes()); // rgfc[0]
+        wd[0x404..0x408].copy_from_slice(&para0_end_fc.to_le_bytes()); // rgfc[1]
+        wd[0x408..0x40C].copy_from_slice(&para1_end_fc.to_le_bytes()); // rgfc[2]
+        // rgbx: byte 0 of each BX is the word offset of that paragraph's PAPX.
+        wd[0x40C] = 19; // para0 PAPX at byte 38 (word 19)
+        wd[0x419] = 21; // para1 PAPX at byte 42 (word 21)
+        // para0 PAPX: cw=2, istd=0 (Normal), empty grpprl.
+        wd[0x426] = 0x02; // cw
+        // 0x427..0x429 = istd 0x0000, 0x429 = grpprl (0x00)
+        // para1 PAPX: cw=5, istd=0 (Normal) — but the grpprl carries
+        // `sprmPOutLvl` (0x2640, 1-byte operand) with outline level 5
+        // (operand 0x04, zero-based). The PAPX is 1 (cw) + 2 (istd) +
+        // 3 (grpprl) = 6 bytes = cb.
+        wd[0x42A] = 0x03; // cw
+        wd[0x42B..0x42D].copy_from_slice(&0x0000u16.to_le_bytes()); // istd = 0 (Normal)
+        // grpprl: 0x2640 (LE) + 1-byte operand 0x04 -> Heading 5.
+        wd[0x42D..0x430].copy_from_slice(&[0x40, 0x26, 0x04]);
+        wd[0x5FF] = 2; // crun = 2
+
+        file[wd_off..wd_off + wd.len()].copy_from_slice(&wd);
+
+        // ── 1Table stream (sectors 6..7) ──
+        let tbl_off = SECTOR + 6 * SECTOR; // byte offset 3584
+        let mut tbl = vec![0u8; TABLE_SECTORS * SECTOR];
+        tbl[0..clx.len()].copy_from_slice(&clx); // CLX at offset 0
+        // PlcfBtePapx at 0x100: n=1 -> [FC0=0][FC1=ccp][BTE=pn 2].
+        tbl[0x100..0x104].copy_from_slice(&0u32.to_le_bytes());
+        tbl[0x104..0x108].copy_from_slice(&ccp.to_le_bytes());
+        tbl[0x108..0x10C].copy_from_slice(&2u32.to_le_bytes());
+        // STSH at 0x120 (0x300 would overflow the 2-sector table stream).
+        tbl[0x120..0x120 + stsh.len()].copy_from_slice(&stsh);
+
+        file[tbl_off..tbl_off + tbl.len()].copy_from_slice(&tbl);
+
+        file
+    }
+
+    /// Write a 128-byte CFB directory entry.
+    fn write_dir_entry(
+        buf: &mut [u8],
+        name: &str,
+        entry_type: u8,
+        child: u32,
+        start_sector: u32,
+        stream_size: u32,
+    ) {
+        let utf16: Vec<u16> = name.encode_utf16().collect();
+        for (i, &ch) in utf16.iter().enumerate() {
+            let bytes = ch.to_le_bytes();
+            buf[i * 2] = bytes[0];
+            buf[i * 2 + 1] = bytes[1];
+        }
+        let name_size = ((utf16.len() + 1) * 2) as u16;
+        buf[0x40..0x42].copy_from_slice(&name_size.to_le_bytes());
+        buf[0x42] = entry_type;
+        buf[0x43] = 1; // color: black
+        buf[0x44..0x48].copy_from_slice(&CFB_FREE.to_le_bytes()); // left sibling
+        buf[0x48..0x4C].copy_from_slice(&CFB_FREE.to_le_bytes()); // right sibling
+        buf[0x4C..0x50].copy_from_slice(&child.to_le_bytes()); // child
+        buf[0x74..0x78].copy_from_slice(&start_sector.to_le_bytes()); // start sector
+        buf[0x78..0x7C].copy_from_slice(&stream_size.to_le_bytes()); // stream size
+    }
+
+    /// Build a CLX with a single Unicode piece whose `fc` points at 0x300 in the
+    /// WordDocument stream (where the document text is placed). `ccp` is the
+    /// total main-text character count.
+    fn build_clx(ccp: u32) -> Vec<u8> {
+        let mut clx = Vec::new();
+        clx.push(0x02); // Pcdt marker
+        clx.extend_from_slice(&16u32.to_le_bytes()); // PlcPcd size = 16
+        clx.extend_from_slice(&0u32.to_le_bytes()); // CP[0]
+        clx.extend_from_slice(&ccp.to_le_bytes()); // CP[1]
+        clx.extend_from_slice(&0u16.to_le_bytes()); // PCD: unused u16
+        clx.extend_from_slice(&0x300u32.to_le_bytes()); // PCD: fc = 0x300 (Unicode)
+        clx.extend_from_slice(&0u16.to_le_bytes()); // PCD: prm
+        clx
+    }
+
+    /// Build one `LPStd` (`cbStd` + `STD` = `StdfBase` + `xstzName`), per
+    /// MS-DOC §2.9.135 / §2.9.258 / §2.9.354.
+    fn lpstd(sti: u16, name: &str) -> Vec<u8> {
+        let mut std = vec![0u8; 10]; // StdfBase
+        std[0..2].copy_from_slice(&sti.to_le_bytes());
+        let units: Vec<u16> = name.encode_utf16().collect();
+        std.extend_from_slice(&(units.len() as u16).to_le_bytes()); // cch
+        for u in &units {
+            std.extend_from_slice(&u.to_le_bytes());
+        }
+        std.extend_from_slice(&0u16.to_le_bytes()); // chTerm
+        let mut out = (std.len() as u16).to_le_bytes().to_vec(); // cbStd
+        out.extend_from_slice(&std);
+        out
+    }
+
+    /// A spec-conformant 15-style STSH (§2.9.271): `cbStshi`(18) then `Stshif`(18),
+    /// followed directly by `rglpstd`, using the fixed-index table — istd 0 is
+    /// Normal (sti 0), istd 1–9 are Heading 1–9 (sti 1–9), and istd 10–14 are
+    /// empty. So `istd 3` is `Heading 3`. Built from the spec, not from our
+    /// parser.
+    fn build_stsh_heading3() -> Vec<u8> {
+        let mut d = 18u16.to_le_bytes().to_vec(); // cbStshi
+        d.extend_from_slice(&15u16.to_le_bytes()); // cstd
+        d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile
+        d.extend_from_slice(&[0u8; 14]); // remainder of the 18-byte Stshif
+        d.extend_from_slice(&lpstd(0, "Normal"));
+        for lvl in 1..=9u16 {
+            d.extend_from_slice(&lpstd(lvl, &format!("Heading {lvl}")));
+        }
+        for _ in 0..5 {
+            d.extend_from_slice(&[0u8; 2]); // empty LPStd (cbStd = 0)
+        }
+        d
+    }
+
+    #[test]
+    fn synthetic_doc_styled_heading_uses_style_sheet_level() {
+        use crate::ir::Element;
+
+        let doc_bytes = build_synthetic_styled_doc("Introduction.");
+        // Round-trip through the full DOC pipeline: CFB parse → FIB → piece
+        // table → PAPX FKP → style sheet → IR. No third-party fixture.
+        let doc = DocDocument::from_reader(std::io::Cursor::new(doc_bytes))
+            .expect("synthetic .doc must parse");
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+
+        let elements = &ir.sections[0].elements;
+        assert_eq!(elements.len(), 2, "expected intro paragraph + styled heading");
+        assert!(
+            matches!(elements[0], Element::Paragraph(_)),
+            "first element must be ordinary body prose"
+        );
+        match &elements[1] {
+            Element::Heading(h) => {
+                // Heading 3 can ONLY come from the style sheet: the line
+                // heuristic tops out at level 2, so level 3 proves the real
+                // style-sheet level reached the IR.
+                assert_eq!(h.level, 3, "styled Heading 3 must keep its real level");
+            },
+            other => panic!("second element must be a Heading, got {:?}", other),
+        }
+        assert_eq!(
+            ir.metadata.title.as_deref(),
+            Some("Subsection Three"),
+            "the styled heading becomes the document title"
+        );
+    }
+
+    /// Regression: a heading resolved from the *style sheet* must **not**
+    /// switch the line-shape guess off for the rest of the document.
+    ///
+    /// The body line here is short and ALL-CAPS with no trailing '.', i.e.
+    /// exactly the shape the guess turns into a heading. Measured on a real
+    /// corpus, letting a style-derived level flip `has_structured_headings`
+    /// collapsed `parentinvguid.doc` from 35 headings to 2: the document
+    /// styled only a few paragraphs and left its 33 section headings as plain
+    /// ALL-CAPS lines, and switching the guess off lost every one of them.
+    ///
+    /// Style-derived levels give the paragraphs that carry them their real
+    /// level; they are not evidence that the whole document is structured.
+    #[test]
+    fn styled_heading_does_not_switch_off_the_line_shape_guess() {
+        use crate::ir::Element;
+
+        let doc_bytes = build_synthetic_styled_doc("SHORT ALL CAPS BODY LINE");
+        let doc = DocDocument::from_reader(std::io::Cursor::new(doc_bytes))
+            .expect("synthetic .doc must parse");
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+
+        let elements = &ir.sections[0].elements;
+        let headings: Vec<_> = elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::Heading(h) => Some(h),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            headings.len(),
+            2,
+            "the styled heading must keep its real level *and* the unstyled ALL-CAPS \
+             line must still be recognised; got {elements:?}"
+        );
+        // The styled one is still Heading 3 — the level came from the style
+        // sheet, which is the point of the change.
+        assert!(
+            headings.iter().any(|h| h.level == 3),
+            "the style-derived level must still be used"
+        );
+    }
+
+    #[test]
+    fn synthetic_doc_outline_sprm_heading() {
+        use crate::ir::Element;
+
+        let doc_bytes = build_synthetic_outline_doc();
+        // Full DOC pipeline: CFB → FIB → piece table → PAPX FKP → IR. The
+        // second paragraph's PAPX carries `sprmPOutLvl` (0x2640, operand 0x04)
+        // in its grpprl with `istd` 0 (Normal), so the Heading level comes
+        // solely from the SPRM — the style-sheet path would resolve istd 0
+        // (Normal) to no heading at all, and the line heuristic tops out at
+        // level 2. Level 5 therefore proves the `sprmPOutLvl` path reached
+        // the IR end to end.
+        let doc = DocDocument::from_reader(std::io::Cursor::new(doc_bytes))
+            .expect("synthetic .doc must parse");
+        let ir = crate::convert_doc::doc_to_ir(&doc);
+
+        let elements = &ir.sections[0].elements;
+        assert_eq!(elements.len(), 2, "expected intro paragraph + SPRM heading");
+        assert!(
+            matches!(elements[0], Element::Paragraph(_)),
+            "first element must be ordinary body prose"
+        );
+        match &elements[1] {
+            Element::Heading(h) => {
+                assert_eq!(h.level, 5, "outline SPRM must set the real level 5");
+            },
+            other => panic!("second element must be a Heading, got {:?}", other),
+        }
+        assert_eq!(
+            ir.metadata.title.as_deref(),
+            Some("Subsection Three"),
+            "the SPRM heading becomes the document title"
+        );
     }
 }

--- a/src/doc/fib.rs
+++ b/src/doc/fib.rs
@@ -41,6 +41,11 @@ pub struct Fib {
     pub fc_plcf_lst: u32,
     /// Byte length of the PlcfLst in the Table stream (0x02E6).
     pub lcb_plcf_lst: u32,
+    /// Offset of the style sheet (`stshf`, an `STSH`) in the Table stream
+    /// (absolute 0x00A2). Zero when the file has no style sheet.
+    pub fc_stshf: u32,
+    /// Byte length of the style sheet in the Table stream (0x00A6).
+    pub lcb_stshf: u32,
 }
 
 impl Fib {
@@ -105,6 +110,14 @@ impl Fib {
             (0, 0)
         };
 
+        // fcStshf / lcbStshf — style sheet (STSH) in the Table stream
+        // (absolute 0x00A2 / 0x00A6). Zero when the file has no style sheet.
+        let (fc_stshf, lcb_stshf) = if data.len() > 0x00A9 {
+            (read_u32(data, 0x00A2), read_u32(data, 0x00A6))
+        } else {
+            (0, 0)
+        };
+
         Ok(Self {
             version,
             use_table1,
@@ -121,6 +134,8 @@ impl Fib {
             lcb_plcf_bte_papx,
             fc_plcf_lst,
             lcb_plcf_lst,
+            fc_stshf,
+            lcb_stshf,
         })
     }
 }

--- a/src/doc/fib.rs
+++ b/src/doc/fib.rs
@@ -41,6 +41,15 @@ pub struct Fib {
     pub fc_plcf_lst: u32,
     /// Byte length of the PlcfLst in the Table stream (0x02E6).
     pub lcb_plcf_lst: u32,
+    /// Offset of the style sheet (`stshf`, an `STSH`) in the Table stream
+    /// (absolute 0x00A2). This is an **offset, not a presence flag**: the
+    /// style sheet is normally the first thing written to the Table stream, so
+    /// `0` is its usual value on real files. Test [`lcb_stshf`] for absence.
+    pub fc_stshf: u32,
+    /// Byte length of the style sheet in the Table stream (0x00A6). The only
+    /// valid absence test: [MS-DOC] `FibRgFcLcb97` requires this to be
+    /// non-zero, and `STSH` states every FIB contains a style sheet.
+    pub lcb_stshf: u32,
 }
 
 impl Fib {
@@ -122,6 +131,15 @@ impl Fib {
             (0, 0)
         };
 
+        // fcStshf / lcbStshf — style sheet (STSH) in the Table stream
+        // (absolute 0x00A2 / 0x00A6). `fcStshf` is an offset whose usual value
+        // is 0; only `lcbStshf` says whether a style sheet is present.
+        let (fc_stshf, lcb_stshf) = if data.len() > 0x00A9 {
+            (read_u32(data, 0x00A2), read_u32(data, 0x00A6))
+        } else {
+            (0, 0)
+        };
+
         Ok(Self {
             version,
             use_table1,
@@ -138,6 +156,8 @@ impl Fib {
             lcb_plcf_bte_papx,
             fc_plcf_lst,
             lcb_plcf_lst,
+            fc_stshf,
+            lcb_stshf,
         })
     }
 }

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -16,6 +16,7 @@ pub mod images;
 mod papx;
 mod piece_table;
 mod sprm;
+pub mod styles;
 
 pub use crate::core::OfficeDocument;
 pub use document::DocDocument;

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -16,6 +16,16 @@ pub mod images;
 mod papx;
 mod piece_table;
 mod sprm;
+pub mod styles;
+
+/// The deepest outline level MS-DOC stores: `Heading 1`–`Heading 9`. The
+/// `StdfBase.sti` and a user-defined `Heading N` style name use this range,
+/// so it lives here — at the `.doc` format root rather than in any one
+/// submodule — and the style-sheet sites read this same bound.
+///
+/// Note `sprmPOutLvl` (0x2640) is **not** in this range: it encodes the level
+/// zero-based, 0x00–0x08 for Heading 1–9, with 0x09 meaning body text.
+pub const MAX_OUTLINE_LEVEL: u8 = 9;
 
 pub use crate::core::OfficeDocument;
 pub use document::{DocDocument, SubDocument, SubDocumentKind};

--- a/src/doc/papx.rs
+++ b/src/doc/papx.rs
@@ -17,7 +17,8 @@
 //! The `grpprl` is decoded by [`super::sprm::extract_pap_props`].
 
 use super::piece_table::{Piece, decode_cp_range, sanitize_text};
-use super::sprm::PapProps;
+use super::sprm::{PapProps, paragraph_style_istd};
+use super::styles::{StyleDef, heading_level_for_istd};
 
 /// A paragraph descriptor recovered from a PAPX FKP page.
 #[derive(Debug, Clone)]
@@ -28,6 +29,15 @@ pub struct FkpParagraph {
     pub fc_end: u32,
     /// The PAP `grpprl` bytes (without the `cw`/`istd` header).
     pub grpprl: Vec<u8>,
+    /// The paragraph style index (`istd`) from the PAPX header, before any
+    /// `sprmPStyle` (0x640A) override carried in the `grpprl`.
+    pub istd: u16,
+}
+
+/// Result of decoding one PAPX: its `grpprl` and the header `istd`.
+struct PapxData {
+    grpprl: Vec<u8>,
+    istd: u16,
 }
 
 /// A fully-resolved main-text paragraph: its raw text, the terminating
@@ -130,28 +140,36 @@ fn parse_fkp_page(page: &[u8], out: &mut Vec<FkpParagraph>) {
         let word_off = page[bx_off] as usize;
         let fc_start = rgfc[i];
         let fc_end = rgfc[i + 1];
-        let grpprl = if word_off == 0 {
-            Vec::new()
+        let papx = if word_off == 0 {
+            PapxData {
+                grpprl: Vec::new(),
+                istd: 0,
+            }
         } else {
             extract_grpprl(page, word_off)
         };
         out.push(FkpParagraph {
             fc_start,
             fc_end,
-            grpprl,
+            grpprl: papx.grpprl,
+            istd: papx.istd,
         });
     }
 }
 
-/// Extract the PAP `grpprl` from a page at the given word offset.
+/// Extract the PAP `grpprl` (and header `istd`) from a page at the given word
+/// offset.
 ///
 /// Layout: `[cw:1][istd:2][grpprl: cb-3]`, `cb = cw * 2`. The Word8 re-read
 /// (`cw == 0` → use the next byte) is applied so row-terminator paragraphs,
 /// which carry the full TAP, are not mistaken for empty PAPXs.
-fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
+fn extract_grpprl(page: &[u8], word_off: usize) -> PapxData {
     let mut p = word_off * 2;
     if p >= page.len() {
-        return Vec::new();
+        return PapxData {
+            grpprl: Vec::new(),
+            istd: 0,
+        };
     }
     let mut cw = page[p] as usize;
     let reread = cw == 0;
@@ -159,14 +177,26 @@ fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
         // Word8 re-read: the real cw is the following byte.
         p += 1;
         if p >= page.len() {
-            return Vec::new();
+            return PapxData {
+                grpprl: Vec::new(),
+                istd: 0,
+            };
         }
         cw = page[p] as usize;
     }
     let cb = cw * 2; // total PAPX bytes for the istd+grpprl block
     if cb < 3 {
-        return Vec::new(); // only cw + istd, no grpprl
+        return PapxData {
+            grpprl: Vec::new(),
+            istd: 0,
+        }; // only cw + istd, no grpprl
     }
+    // `istd` is the 2 bytes immediately after `cw` (post-reread), before grpprl.
+    let istd = if p + 3 <= page.len() {
+        u16::from_le_bytes([page[p + 1], page[p + 2]])
+    } else {
+        0
+    };
     let grpprl_start = p + 3; // skip cw (1) + istd (2)
     // Per MS-DOC §2.9.175 (PapxInFkp) the grpprl length differs by form:
     //  • cw != 0: grpprlInPapx *is* a GrpPrlAndIstd of `2*cw - 1` bytes, so the
@@ -177,9 +207,15 @@ fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
     //    truncate the trailing SPRM (e.g. the row's TAP).
     let grpprl_end = (p + cb + if reread { 1 } else { 0 }).min(page.len());
     if grpprl_start >= grpprl_end {
-        return Vec::new();
+        return PapxData {
+            grpprl: Vec::new(),
+            istd,
+        };
     }
-    page[grpprl_start..grpprl_end].to_vec()
+    PapxData {
+        grpprl: page[grpprl_start..grpprl_end].to_vec(),
+        istd,
+    }
 }
 
 /// Convert a character position to a real byte offset in the WordDocument
@@ -280,6 +316,7 @@ pub fn build_paragraphs(
     pieces: &[Piece],
     fkp: &[FkpParagraph],
     text_len: u32,
+    styles: &[StyleDef],
 ) -> Vec<DocParagraph> {
     let mut keyed: Vec<(u32, &FkpParagraph)> = fkp
         .iter()
@@ -304,7 +341,15 @@ pub fn build_paragraphs(
         }
         let terminator = chars[chars.len() - 1];
         let content: String = sanitize_text(&chars[..chars.len() - 1].iter().collect::<String>());
-        let props = super::sprm::extract_pap_props(&fp.grpprl);
+        let mut props = super::sprm::extract_pap_props(&fp.grpprl);
+        // Resolve the heading level from the paragraph's style. A `sprmPStyle`
+        // (0x640A) in the grpprl overrides the PAPX `istd`; otherwise use the
+        // PAPX `istd`. A `sprmPOutlineLvl` (0x6412) already sets
+        // `heading_level` directly and takes precedence when present.
+        let istd = paragraph_style_istd(&fp.grpprl).unwrap_or(fp.istd);
+        if props.heading_level.is_none() {
+            props.heading_level = heading_level_for_istd(styles, istd);
+        }
         out.push(DocParagraph {
             text: content,
             terminator,
@@ -319,6 +364,7 @@ mod tests {
     use super::*;
     use crate::doc::piece_table::Piece;
     use crate::doc::sprm::extract_pap_props;
+    use crate::doc::styles::StyleDef;
 
     fn unicode_piece(fc: u32, cp_end: u32) -> Piece {
         Piece {
@@ -410,6 +456,7 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: grpprl.to_vec(),
+            istd: 0,
         };
         let cell = [0x16, 0x24, 0x01, 0x49, 0x66, 0x01, 0x00, 0x00, 0x00];
         let rowmark = [
@@ -423,7 +470,7 @@ mod tests {
             mk(5, 6, &rowmark), // "\u{7}" row mark
         ];
 
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 6);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 6, &[]);
         assert_eq!(paras.len(), 4);
         // leading mark
         assert_eq!(paras[0].text, "");
@@ -460,10 +507,11 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: Vec::new(),
+            istd: 0,
         };
         let fkp = vec![mk(0, 6), mk(6, 12)];
 
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 12);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 12, &[]);
         assert_eq!(paras.len(), 2);
         assert_eq!(paras[0].text, "Hi 😀", "emoji must not desync the range");
         assert_eq!(paras[0].terminator, '\r');
@@ -486,9 +534,10 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: Vec::new(),
+            istd: 0,
         };
         let fkp = vec![mk(0, raw.chars().count() as u32)];
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &[]);
         assert_eq!(paras.len(), 1);
         assert_eq!(paras[0].terminator, '\r');
         let t = &paras[0].text;
@@ -497,6 +546,42 @@ mod tests {
         assert!(!t.contains('\u{15}'), "field end must be stripped");
         assert!(t.contains("HYPERLINK"), "field result text survives");
         assert_eq!(t, "SeeHYPERLINKresulthere");
+    }
+
+    /// Regression: a paragraph whose PAPX `istd` points at a built-in `Heading N`
+    /// style (sti 1..9) must resolve to `heading_level == Some(N)` via the style
+    /// sheet, even when no `sprmPOutlineLvl` (0x6412) is present. This is the
+    /// style-sheet fallback path that replaces the line heuristic for styled
+    /// headings.
+    #[test]
+    fn build_paragraphs_resolves_heading_from_style_istd() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 3,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.heading_level,
+            Some(3),
+            "built-in Heading style must resolve to its level"
+        );
     }
 
     /// Regression: the `cw == 0` Word8 re-read branch must not drop the trailing
@@ -532,7 +617,7 @@ mod tests {
         page[4..4 + 32].copy_from_slice(&grpprl);
 
         let extracted = extract_grpprl(&page, 0);
-        let props = extract_pap_props(&extracted);
+        let props = extract_pap_props(&extracted.grpprl);
         assert!(
             props.tap.is_some(),
             "cw==0 re-read must keep the full grpprl so the trailing TAP parses"

--- a/src/doc/papx.rs
+++ b/src/doc/papx.rs
@@ -362,9 +362,10 @@ pub fn build_paragraphs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::doc::fib::Fib;
     use crate::doc::piece_table::Piece;
     use crate::doc::sprm::extract_pap_props;
-    use crate::doc::styles::StyleDef;
+    use crate::doc::styles::{StyleDef, parse_style_sheet};
 
     fn unicode_piece(fc: u32, cp_end: u32) -> Piece {
         Piece {
@@ -655,6 +656,100 @@ mod tests {
             paras[0].props.heading_level,
             Some(3),
             "user-defined `heading N` name must resolve to its level"
+        );
+    }
+
+    /// A 4-style STSH (indices 0..3): `Normal`, two empty slots, and a built-in
+    /// `Heading 3` (sti 3). Mirrors the layout `parse_stsh` expects: an 18-byte
+    /// Stshif (cstd = 4), a style-name STTB, then 4 LPStd entries.
+    fn stsh_with_heading_3() -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&18u16.to_le_bytes()); // cbStshi
+        d.extend_from_slice(&4u16.to_le_bytes()); // cstd = 4
+        d.extend_from_slice(&10u16.to_le_bytes()); // cbSTDBaseInFile
+        d.extend_from_slice(&[0u8; 14]); // remainder of the 18-byte Stshif
+        // Style-name STTB (f2 = 1, cData = 4, cbData = 0).
+        d.push(1);
+        d.extend_from_slice(&4u16.to_le_bytes());
+        d.extend_from_slice(&0u16.to_le_bytes());
+        for name in ["Normal", "", "", "Heading 3"] {
+            if name.is_empty() {
+                d.extend_from_slice(&0u16.to_le_bytes());
+            } else {
+                d.extend_from_slice(&(name.len() as u16).to_le_bytes());
+                for c in name.encode_utf16() {
+                    d.extend_from_slice(&c.to_le_bytes());
+                }
+            }
+        }
+        d.extend_from_slice(&0u16.to_le_bytes()); // trailing null string
+        // 4 LPStd entries: cbStd = 10 + StdfBase (sti in low 2 bytes).
+        for &sti in &[0u16, 0u16, 0u16, 3u16] {
+            d.extend_from_slice(&10u16.to_le_bytes());
+            d.extend_from_slice(&sti.to_le_bytes());
+            d.extend_from_slice(&[0u8; 8]);
+        }
+        d
+    }
+
+    fn fib_with_stsh(start: u32, len: u32) -> Fib {
+        Fib {
+            version: 0,
+            use_table1: false,
+            clx_offset: 0,
+            clx_size: 0,
+            text_len: 0,
+            footnote_len: 0,
+            header_len: 0,
+            comment_len: 0,
+            endnote_len: 0,
+            textbox_len: 0,
+            header_textbox_len: 0,
+            fc_plcf_bte_papx: 0,
+            lcb_plcf_bte_papx: 0,
+            fc_plcf_lst: 0,
+            lcb_plcf_lst: 0,
+            fc_stshf: start,
+            lcb_stshf: len,
+        }
+    }
+
+    /// Integration: drive the FIB-aware `parse_style_sheet` (the call
+    /// `document.rs` makes) and feed its result into `build_paragraphs`, exactly
+    /// as the real `.doc` walk does — but with a synthetic Table stream instead
+    /// of a parsed CFB. The POI corpus cannot exercise this (every file reports
+    /// `fc_stshf == 0`), so this is the regression guard that stands in for a
+    /// "real .doc with a style sheet": a paragraph styled `Heading 3` (istd 3)
+    /// must resolve to level 3 through the full byte-to-IR pipeline.
+    #[test]
+    fn build_paragraphs_resolves_heading_from_parsed_style_sheet() {
+        let stsh = stsh_with_heading_3();
+        let start = 64usize;
+        let mut table_stream = vec![0u8; start + stsh.len()];
+        table_stream[start..start + stsh.len()].copy_from_slice(&stsh);
+        let fib = fib_with_stsh(start as u32, stsh.len() as u32);
+        let styles = parse_style_sheet(&table_stream, &fib);
+        assert_eq!(styles.len(), 4);
+        assert_eq!(styles[3].sti, 3);
+        assert_eq!(styles[3].name, "Heading 3");
+
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 3,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.heading_level,
+            Some(3),
+            "heading must resolve from a style sheet obtained via parse_style_sheet"
         );
     }
 

--- a/src/doc/papx.rs
+++ b/src/doc/papx.rs
@@ -584,6 +584,80 @@ mod tests {
         );
     }
 
+    /// Regression: a `sprmPStyle` (0x640A) carried in the grpprl must override
+    /// the PAPX `istd` when resolving the style sheet. A paragraph whose PAPX
+    /// header says `Normal` (istd 0) but whose grpprl re-styles it to
+    /// `Heading 3` must resolve to level 3 — not `None`, and not whatever the
+    /// PAPX `istd` alone would have resolved to (which here is nothing).
+    #[test]
+    fn build_paragraphs_prefers_sprm_style_over_papx_istd() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // PAPX `istd` = 0 (Normal), but the grpprl carries `sprmPStyle` (0x640A,
+        // spra-3 => 4-byte operand) re-pointing at istd 3. The low two operand
+        // bytes are the target istd.
+        let grpprl = vec![0x0A, 0x64, 0x03, 0x00, 0x00, 0x00];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 0,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.heading_level,
+            Some(3),
+            "`sprmPStyle` override must win over the PAPX `istd`"
+        );
+    }
+
+    /// Regression: a user-defined heading style (sti 0x0FFE, name carries the
+    /// level) must resolve via its name, case-insensitively, through the full
+    /// `build_paragraphs` pipeline. Here the style name is lowercase
+    /// `"heading 3"` to prove the lookup is not case-sensitive.
+    #[test]
+    fn build_paragraphs_resolves_user_heading_name_case_insensitive() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef {
+                sti: 0x0FFE,
+                name: "heading 3".into(),
+            }, // istd 2: user-defined, name carries level
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 2,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.heading_level,
+            Some(3),
+            "user-defined `heading N` name must resolve to its level"
+        );
+    }
+
     /// Regression: the `cw == 0` Word8 re-read branch must not drop the trailing
     /// byte of the grpprl. Per [MS-DOC] §2.9.175 (PapxInFkp), the
     /// re-read form is `[cb':1][GrpPrlAndIstd: 2*cb']`, so the grpprl is

--- a/src/doc/papx.rs
+++ b/src/doc/papx.rs
@@ -18,6 +18,7 @@
 
 use super::piece_table::{Piece, decode_cp_range, sanitize_text};
 use super::sprm::PapProps;
+use super::styles::{StyleDef, heading_level_for_istd};
 
 /// A paragraph descriptor recovered from a PAPX FKP page.
 #[derive(Debug, Clone)]
@@ -28,6 +29,15 @@ pub struct FkpParagraph {
     pub fc_end: u32,
     /// The PAP `grpprl` bytes (without the `cw`/`istd` header).
     pub grpprl: Vec<u8>,
+    /// The paragraph style index (`istd`) from the PAPX header, before any
+    /// `sprmPIstd` (0x4600) override carried in the `grpprl`.
+    pub istd: u16,
+}
+
+/// Result of decoding one PAPX: its `grpprl` and the header `istd`.
+struct PapxData {
+    grpprl: Vec<u8>,
+    istd: u16,
 }
 
 /// A fully-resolved main-text paragraph: its raw text, the terminating
@@ -130,28 +140,36 @@ fn parse_fkp_page(page: &[u8], out: &mut Vec<FkpParagraph>) {
         let word_off = page[bx_off] as usize;
         let fc_start = rgfc[i];
         let fc_end = rgfc[i + 1];
-        let grpprl = if word_off == 0 {
-            Vec::new()
+        let papx = if word_off == 0 {
+            PapxData {
+                grpprl: Vec::new(),
+                istd: 0,
+            }
         } else {
             extract_grpprl(page, word_off)
         };
         out.push(FkpParagraph {
             fc_start,
             fc_end,
-            grpprl,
+            grpprl: papx.grpprl,
+            istd: papx.istd,
         });
     }
 }
 
-/// Extract the PAP `grpprl` from a page at the given word offset.
+/// Extract the PAP `grpprl` (and header `istd`) from a page at the given word
+/// offset.
 ///
 /// Layout: `[cw:1][istd:2][grpprl: cb-3]`, `cb = cw * 2`. The Word8 re-read
 /// (`cw == 0` → use the next byte) is applied so row-terminator paragraphs,
 /// which carry the full TAP, are not mistaken for empty PAPXs.
-fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
+fn extract_grpprl(page: &[u8], word_off: usize) -> PapxData {
     let mut p = word_off * 2;
     if p >= page.len() {
-        return Vec::new();
+        return PapxData {
+            grpprl: Vec::new(),
+            istd: 0,
+        };
     }
     let mut cw = page[p] as usize;
     let reread = cw == 0;
@@ -159,14 +177,26 @@ fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
         // Word8 re-read: the real cw is the following byte.
         p += 1;
         if p >= page.len() {
-            return Vec::new();
+            return PapxData {
+                grpprl: Vec::new(),
+                istd: 0,
+            };
         }
         cw = page[p] as usize;
     }
     let cb = cw * 2; // total PAPX bytes for the istd+grpprl block
     if cb < 3 {
-        return Vec::new(); // only cw + istd, no grpprl
+        return PapxData {
+            grpprl: Vec::new(),
+            istd: 0,
+        }; // only cw + istd, no grpprl
     }
+    // `istd` is the 2 bytes immediately after `cw` (post-reread), before grpprl.
+    let istd = if p + 3 <= page.len() {
+        u16::from_le_bytes([page[p + 1], page[p + 2]])
+    } else {
+        0
+    };
     let grpprl_start = p + 3; // skip cw (1) + istd (2)
     // Per MS-DOC §2.9.175 (PapxInFkp) the grpprl length differs by form:
     //  • cw != 0: grpprlInPapx *is* a GrpPrlAndIstd of `2*cw - 1` bytes, so the
@@ -177,9 +207,15 @@ fn extract_grpprl(page: &[u8], word_off: usize) -> Vec<u8> {
     //    truncate the trailing SPRM (e.g. the row's TAP).
     let grpprl_end = (p + cb + if reread { 1 } else { 0 }).min(page.len());
     if grpprl_start >= grpprl_end {
-        return Vec::new();
+        return PapxData {
+            grpprl: Vec::new(),
+            istd,
+        };
     }
-    page[grpprl_start..grpprl_end].to_vec()
+    PapxData {
+        grpprl: page[grpprl_start..grpprl_end].to_vec(),
+        istd,
+    }
 }
 
 /// Convert a character position to a real byte offset in the WordDocument
@@ -262,6 +298,34 @@ fn piece_byte_base(p: &Piece) -> (u32, u32) {
     }
 }
 
+/// Resolve a paragraph's outline level in [MS-DOC]'s **zero-based** value space
+/// (`0` = Heading 1 … `8` = Heading 9), or `None` when it is body text.
+///
+/// The precedence is one documented rule. Direct formatting overrides the style
+/// in Word, so `sprmPOutLvl` (0x2640) settles the question whenever the
+/// grpprl carries a valid one:
+///
+/// - present with operand `0x00`–`0x08` → that level, and the style is never
+///   consulted;
+/// - present with operand `0x09` → an explicit body-text marker: `None`, and
+///   again the style is never consulted (a paragraph styled `Heading 3` but
+///   demoted to body text stays body text);
+/// - absent, or carrying an operand that is not a valid outline level → fall
+///   back to the paragraph's style, `istd`, which the caller has already
+///   resolved from the PAPX header and any `sprmPIstd` (0x4600) override.
+fn resolve_outline_level(props: &PapProps, istd: u16, styles: &[StyleDef]) -> Option<u8> {
+    if props.outline_lvl_explicit {
+        // Settled by direct formatting: either a real level or an explicit
+        // body-text marker (`None`). `extract_pap_props` already stored it.
+        props.outline_level
+    } else {
+        // `heading_level_for_istd` is 1-based (Heading 1–9); the field is
+        // zero-based. The level is at least 1 whenever it is `Some`, so this
+        // cannot underflow.
+        heading_level_for_istd(styles, istd).map(|level| level - 1)
+    }
+}
+
 /// Build the main-text paragraph list for `doc_to_ir`.
 ///
 /// Walks the PAPX FKP paragraphs, keeps only those whose start CP falls in
@@ -280,6 +344,7 @@ pub fn build_paragraphs(
     pieces: &[Piece],
     fkp: &[FkpParagraph],
     text_len: u32,
+    styles: &[StyleDef],
 ) -> Vec<DocParagraph> {
     let mut keyed: Vec<(u32, &FkpParagraph)> = fkp
         .iter()
@@ -304,7 +369,17 @@ pub fn build_paragraphs(
         }
         let terminator = chars[chars.len() - 1];
         let content: String = sanitize_text(&chars[..chars.len() - 1].iter().collect::<String>());
-        let props = super::sprm::extract_pap_props(&fp.grpprl);
+        // `extract_pap_props` walks the grpprl once, decoding every PAP SPRM —
+        // including `sprmPIstd` (0x4600) into `style_istd` and
+        // `sprmPOutLvl` (0x2640) into `outline_level`.
+        let mut props = super::sprm::extract_pap_props(&fp.grpprl);
+        let istd = props.style_istd.unwrap_or(fp.istd);
+        // The single write: whichever source decided, the result lands in
+        // `outline_level`, which is what `convert_doc` reads both for the level
+        // and for the `has_structured_headings` gate. Without a style-derived
+        // level reaching this field, the line-shape guess would keep running
+        // alongside the real one.
+        props.outline_level = resolve_outline_level(&props, istd, styles);
         out.push(DocParagraph {
             text: content,
             terminator,
@@ -317,8 +392,11 @@ pub fn build_paragraphs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::doc::MAX_OUTLINE_LEVEL;
+    use crate::doc::fib::Fib;
     use crate::doc::piece_table::Piece;
     use crate::doc::sprm::extract_pap_props;
+    use crate::doc::styles::{StyleDef, parse_style_sheet};
 
     fn unicode_piece(fc: u32, cp_end: u32) -> Piece {
         Piece {
@@ -410,6 +488,7 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: grpprl.to_vec(),
+            istd: 0,
         };
         let cell = [0x16, 0x24, 0x01, 0x49, 0x66, 0x01, 0x00, 0x00, 0x00];
         let rowmark = [
@@ -423,7 +502,7 @@ mod tests {
             mk(5, 6, &rowmark), // "\u{7}" row mark
         ];
 
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 6);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 6, &[]);
         assert_eq!(paras.len(), 4);
         // leading mark
         assert_eq!(paras[0].text, "");
@@ -460,10 +539,11 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: Vec::new(),
+            istd: 0,
         };
         let fkp = vec![mk(0, 6), mk(6, 12)];
 
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 12);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, 12, &[]);
         assert_eq!(paras.len(), 2);
         assert_eq!(paras[0].text, "Hi 😀", "emoji must not desync the range");
         assert_eq!(paras[0].terminator, '\r');
@@ -486,9 +566,10 @@ mod tests {
             fc_start: 0x800 + cp0 * 2,
             fc_end: 0x800 + cp1 * 2,
             grpprl: Vec::new(),
+            istd: 0,
         };
         let fkp = vec![mk(0, raw.chars().count() as u32)];
-        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32);
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &[]);
         assert_eq!(paras.len(), 1);
         assert_eq!(paras[0].terminator, '\r');
         let t = &paras[0].text;
@@ -497,6 +578,424 @@ mod tests {
         assert!(!t.contains('\u{15}'), "field end must be stripped");
         assert!(t.contains("HYPERLINK"), "field result text survives");
         assert_eq!(t, "SeeHYPERLINKresulthere");
+    }
+
+    /// Regression: a paragraph whose PAPX `istd` points at a built-in `Heading N`
+    /// style (sti 1..9) must resolve to a zero-based `outline_level` via the style
+    /// sheet, even when no `sprmPOutLvl` (0x2640) is present. This is the
+    /// style-sheet fallback path that replaces the line heuristic for styled
+    /// headings.
+    #[test]
+    fn build_paragraphs_resolves_heading_from_style_istd() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 3,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(2),
+            "built-in Heading style must resolve to its level"
+        );
+    }
+
+    /// Regression: a `sprmPIstd` (0x4600) carried in the grpprl must override
+    /// the PAPX `istd` when resolving the style sheet. A paragraph whose PAPX
+    /// header says `Normal` (istd 0) but whose grpprl re-styles it to
+    /// `Heading 3` must resolve to level 3 — not `None`, and not whatever the
+    /// PAPX `istd` alone would have resolved to (which here is nothing).
+    #[test]
+    fn build_paragraphs_prefers_sprm_style_over_papx_istd() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // PAPX `istd` = 0 (Normal), but the grpprl carries `sprmPIstd` (0x4600,
+        // spra-3 => 4-byte operand) re-pointing at istd 3. The low two operand
+        // bytes are the target istd.
+        let grpprl = vec![0x00, 0x46, 0x03, 0x00];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 0,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(2),
+            "`sprmPIstd` override must win over the PAPX `istd`"
+        );
+    }
+
+    /// Regression: a user-defined heading style (sti 0x0FFE, name carries the
+    /// level) must resolve via its name, case-insensitively, through the full
+    /// `build_paragraphs` pipeline. Here the style name is lowercase
+    /// `"heading 3"` to prove the lookup is not case-sensitive.
+    #[test]
+    fn build_paragraphs_resolves_user_heading_name_case_insensitive() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef {
+                sti: 0x0FFE,
+                name: "heading 3".into(),
+            }, // istd 2: user-defined, name carries level
+        ];
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 2,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(2),
+            "user-defined `heading N` name must resolve to its level"
+        );
+    }
+
+    /// Regression: `sprmPOutLvl` (0x2640) carried in the grpprl must set the
+    /// heading level directly, with no style sheet involved. The opcode is
+    /// 0x2640 (LE) + a 1-byte operand holding the zero-based level; here
+    /// `5` must surface as Heading 5. This is the headline "outline SPRM" path
+    /// and was previously only covered at the `extract_pap_props` layer — this
+    /// test proves it flows through `FKP → build_paragraphs → props.outline_level`.
+    #[test]
+    fn build_paragraphs_resolves_heading_from_sprm_out_lvl() {
+        let styles = vec![StyleDef::default()]; // istd 0: Normal
+        let raw = "Section Five\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // grpprl = 0x2640 (LE) + 1-byte operand 0x04 -> Heading 5.
+        let grpprl = vec![0x40, 0x26, 0x04];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 0, // PAPX says Normal; the SPRM overrides it to Heading 5
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(4),
+            "`sprmPOutLvl` must set the heading level directly"
+        );
+    }
+
+    /// Regression: when both a heading style and `sprmPOutLvl` are present,
+    /// the SPRM is authoritative and wins. Here the style (istd 3, built-in
+    /// Heading 3) would resolve to level 3, but the grpprl's `sprmPOutLvl`
+    /// level 5 must take precedence — proving the documented precedence
+    /// (`props.outline_level` is only filled from the style when the SPRM left
+    /// it `None`).
+    #[test]
+    fn build_paragraphs_sprm_out_lvl_overrides_style() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Section Five\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let grpprl = vec![0x40, 0x26, 0x04];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 3, // would resolve to Heading 3 on its own
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(4),
+            "`sprmPOutLvl` must override the style-derived level"
+        );
+    }
+
+    /// Build one `LPStd` for a synthetic style sheet: `cbStd(u16)` + `STD`,
+    /// where `STD` = `StdfBase` (10 bytes, `sti` in its low 12 bits) +
+    /// `xstzName` (`cch` + code units + 2-byte null) — MS-DOC §2.9.135,
+    /// §2.9.258, §2.9.354.
+    /// With a style sheet present but no heading signal on the paragraph, the
+    /// level must stay `None` so the `.doc` walk falls back to the line-based
+    /// heuristic. The other tests in this file mostly pass `&[]` for `styles`;
+    /// this one pins the behaviour with a *populated* style sheet, which is the
+    /// case a real document with a style sheet hits for its body text.
+    #[test]
+    fn build_paragraphs_leaves_body_text_unheaded_with_styles_present() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 1: a heading style exists in the document
+        ];
+        let raw = "Ordinary body prose.\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 0, // Normal
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level, None,
+            "body text stays unheaded even when the style sheet contains heading styles, \
+             so the caller falls back to the heuristic"
+        );
+    }
+
+    /// The `sprmPIstd` override must work in **both** directions. The existing
+    /// test covers restyling a `Normal` paragraph up to `Heading 3`; this covers
+    /// restyling a `Heading 3` paragraph down to `Normal`, which must *remove*
+    /// the heading rather than leaving the PAPX `istd`'s level in place.
+    #[test]
+    fn build_paragraphs_sprm_istd_override_can_remove_a_heading() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Restyled to body text\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // PAPX `istd` = 3 (Heading 3) but `sprmPIstd` (0x4600) restyles it to
+        // istd 0 (Normal), so the heading must go away.
+        let grpprl = vec![0x00, 0x46, 0x00, 0x00];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 3,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level, None,
+            "`sprmPIstd` restyling a heading down to Normal must drop the heading"
+        );
+    }
+
+    /// An explicit `sprmPOutLvl` of 0x09 marks the paragraph as **body text**.
+    /// Direct formatting overrides the style in Word, so such a paragraph must
+    /// not fall back to its style: a paragraph whose style is `Heading 3` but
+    /// which is explicitly marked body text is body text.
+    ///
+    /// This pins the difference between "the SPRM is absent" (consult the
+    /// style) and "the SPRM is present with level 0" (settle it as body text).
+    #[test]
+    fn build_paragraphs_sprm_out_lvl_body_marker_suppresses_styled_heading() {
+        let styles = vec![
+            StyleDef::default(), // istd 0: Normal
+            StyleDef::default(), // istd 1
+            StyleDef::default(), // istd 2
+            StyleDef {
+                sti: 3,
+                name: "Heading 3".into(),
+            }, // istd 3: built-in Heading 3
+        ];
+        let raw = "Not a heading\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // 0x2640 (LE) + 1-byte operand 0x09 (explicit body text).
+        let grpprl = vec![0x40, 0x26, 0x09];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 3, // the style alone would resolve to Heading 3
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level, None,
+            "an explicit outline level 0 must suppress the style-derived heading"
+        );
+    }
+
+    /// MS-DOC outline levels run to `MAX_OUTLINE_LEVEL` and `sprmPOutLvl`
+    /// accepts that whole range; the clamp to the IR's 1..=MAX_HEADING_DEPTH
+    /// depth happens later, at `emit_prose`. This pins the boundary: the SPRM
+    /// path must neither reject the deepest level nor pre-clamp it.
+    #[test]
+    fn build_paragraphs_sprm_out_lvl_accepts_deepest_level() {
+        let styles = vec![StyleDef::default()]; // istd 0: Normal
+        let raw = "Deep section\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        // 0x2640 (LE) + 1-byte operand, the deepest zero-based level (0x08).
+        let grpprl = vec![0x40, 0x26, MAX_OUTLINE_LEVEL - 1];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl,
+            istd: 0,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(MAX_OUTLINE_LEVEL - 1),
+            "the outline SPRM accepts the full 1..=MAX_OUTLINE_LEVEL range; clamping to \
+             the IR depth is the IR boundary's job, not this one"
+        );
+    }
+
+    fn lpstd(sti: u16, name: &str) -> Vec<u8> {
+        let mut std = vec![0u8; 10]; // StdfBase
+        std[0..2].copy_from_slice(&sti.to_le_bytes());
+        let units: Vec<u16> = name.encode_utf16().collect();
+        std.extend_from_slice(&(units.len() as u16).to_le_bytes()); // cch
+        for u in &units {
+            std.extend_from_slice(&u.to_le_bytes());
+        }
+        std.extend_from_slice(&0u16.to_le_bytes()); // chTerm
+        let mut out = (std.len() as u16).to_le_bytes().to_vec(); // cbStd
+        out.extend_from_slice(&std);
+        out
+    }
+
+    /// A spec-conformant 15-style STSH (§2.9.271): `cbStshi`(18) then `Stshif`(18),
+    /// followed directly by `rglpstd`, using the fixed-index table — istd 0 is
+    /// Normal (sti 0), istd 1–9 are Heading 1–9 (sti 1–9), and istd 10–14 are
+    /// empty. So `istd 3` is `Heading 3`. Built from the spec, not from our
+    /// parser.
+    fn stsh_with_heading_3() -> Vec<u8> {
+        let mut d = 18u16.to_le_bytes().to_vec(); // cbStshi
+        d.extend_from_slice(&15u16.to_le_bytes()); // cstd
+        d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile
+        d.extend_from_slice(&[0u8; 14]); // remainder of the 18-byte Stshif
+        d.extend_from_slice(&lpstd(0, "Normal"));
+        for lvl in 1..=9u16 {
+            d.extend_from_slice(&lpstd(lvl, &format!("Heading {lvl}")));
+        }
+        for _ in 0..5 {
+            d.extend_from_slice(&[0u8; 2]); // empty LPStd (cbStd = 0)
+        }
+        d
+    }
+
+    fn fib_with_stsh(start: u32, len: u32) -> Fib {
+        Fib {
+            version: 0,
+            use_table1: false,
+            clx_offset: 0,
+            clx_size: 0,
+            text_len: 0,
+            footnote_len: 0,
+            header_len: 0,
+            comment_len: 0,
+            endnote_len: 0,
+            textbox_len: 0,
+            header_textbox_len: 0,
+            fc_plcf_bte_papx: 0,
+            lcb_plcf_bte_papx: 0,
+            fc_plcf_lst: 0,
+            lcb_plcf_lst: 0,
+            fc_stshf: start,
+            lcb_stshf: len,
+        }
+    }
+
+    /// Integration: drive the FIB-aware `parse_style_sheet` (the call
+    /// `document.rs` makes) and feed its result into `build_paragraphs`, exactly
+    /// as the real `.doc` walk does — but with a synthetic Table stream instead
+    /// of a parsed CFB. The POI corpus cannot exercise this (every file reports
+    /// `fc_stshf == 0`), so this is the regression guard that stands in for a
+    /// "real .doc with a style sheet": a paragraph styled `Heading 3` (istd 3)
+    /// must resolve to level 3 through the full byte-to-IR pipeline.
+    #[test]
+    fn build_paragraphs_resolves_heading_from_parsed_style_sheet() {
+        let stsh = stsh_with_heading_3();
+        let start = 64usize;
+        let mut table_stream = vec![0u8; start + stsh.len()];
+        table_stream[start..start + stsh.len()].copy_from_slice(&stsh);
+        let fib = fib_with_stsh(start as u32, stsh.len() as u32);
+        let styles = parse_style_sheet(&table_stream, &fib);
+        assert_eq!(styles.len(), 15, "the 15 fixed-index LPStd entries");
+        assert_eq!(styles[3].sti, 3);
+        assert_eq!(styles[3].name, "Heading 3");
+
+        let raw = "Subsection\r";
+        let text_bytes: Vec<u8> = raw.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut word_doc = vec![0u8; 0x800 + text_bytes.len()];
+        word_doc[0x800..0x800 + text_bytes.len()].copy_from_slice(&text_bytes);
+        let pieces = [unicode_piece(0x800, raw.chars().count() as u32)];
+        let fkp = [FkpParagraph {
+            fc_start: 0x800,
+            fc_end: 0x800 + raw.chars().count() as u32 * 2,
+            grpprl: Vec::new(),
+            istd: 3,
+        }];
+        let paras = build_paragraphs(&word_doc, &pieces, &fkp, raw.chars().count() as u32, &styles);
+        assert_eq!(paras.len(), 1);
+        assert_eq!(
+            paras[0].props.outline_level,
+            Some(2),
+            "heading must resolve from a style sheet obtained via parse_style_sheet"
+        );
     }
 
     /// Regression: the `cw == 0` Word8 re-read branch must not drop the trailing
@@ -532,7 +1031,7 @@ mod tests {
         page[4..4 + 32].copy_from_slice(&grpprl);
 
         let extracted = extract_grpprl(&page, 0);
-        let props = extract_pap_props(&extracted);
+        let props = extract_pap_props(&extracted.grpprl);
         assert!(
             props.tap.is_some(),
             "cw==0 re-read must keep the full grpprl so the trailing TAP parses"

--- a/src/doc/papx.rs
+++ b/src/doc/papx.rs
@@ -840,7 +840,9 @@ mod tests {
     /// which is explicitly marked body text is body text.
     ///
     /// This pins the difference between "the SPRM is absent" (consult the
-    /// style) and "the SPRM is present with level 0" (settle it as body text).
+    /// style) and "the SPRM is present with operand `0x09`", the body-text
+    /// marker (settle it as body text). The marker is `0x09`, *not* `0x00`:
+    /// `0x00` is Heading 1.
     #[test]
     fn build_paragraphs_sprm_out_lvl_body_marker_suppresses_styled_heading() {
         let styles = vec![
@@ -869,7 +871,7 @@ mod tests {
         assert_eq!(paras.len(), 1);
         assert_eq!(
             paras[0].props.outline_level, None,
-            "an explicit outline level 0 must suppress the style-derived heading"
+            "an explicit body-text marker (operand 0x09) must suppress the style-derived heading"
         );
     }
 

--- a/src/doc/sprm.rs
+++ b/src/doc/sprm.rs
@@ -215,6 +215,27 @@ pub struct PapProps {
     /// list/tab-stop PR; in the tables-only PR this field is always empty, but
     /// it is cloned through the IR so the `Paragraph.tabs` shape stays uniform.
     pub tabs: Vec<TabStop>,
+    /// Resolved heading level (1–9) when this paragraph is a heading, derived
+    /// either from `sprmPOutlineLvl` (0x6412) carried directly in the grpprl,
+    /// or from the paragraph's style (the PAPX `istd`, optionally overridden by
+    /// `sprmPStyle` 0x640A) looked up in the document style sheet — see
+    /// `crate::doc::styles`. `None` means "not a heading" (body text), and the
+    /// `.doc` walk falls back to the line-based heading heuristic in that case.
+    pub heading_level: Option<u8>,
+}
+
+/// Scan a PAP `grpprl` for `sprmPStyle` (0x640A) and return the style index
+/// (`istd`) it overrides the PAPX header with, if present.
+///
+/// The PAPX header `istd` is the default style; a direct `sprmPStyle` SPRM
+/// takes precedence. Returns `None` when the grpprl carries no style SPRM.
+pub fn paragraph_style_istd(grpprl: &[u8]) -> Option<u16> {
+    for sprm in parse_grpprl(grpprl) {
+        if sprm.opcode == 0x640A && sprm.operand.len() >= 2 {
+            return Some(u16::from_le_bytes([sprm.operand[0], sprm.operand[1]]));
+        }
+    }
+    None
 }
 
 /// One table cell descriptor (TKBKTAP, 20 bytes) distilled from a row's
@@ -420,6 +441,22 @@ pub fn extract_pap_props(grpprl: &[u8]) -> PapProps {
                     props.ilvl = Some(b);
                 }
             },
+            // sprmPOutlineLvl (0x6412) — the 4-byte operand's low byte is the
+            // outline level: `0` = body text, `1`–`9` = Heading 1–9 (MS-DOC
+            // §2.9.138). This is the authoritative heading marker and wins over
+            // any style-derived level resolved later in `build_paragraphs`.
+            //
+            // Use the raw low byte and validate the `1..=9` range. A coincidental
+            // byte pattern that merely *contains* the opcode must not be turned
+            // into a heading: e.g. an operand low byte of 0x68 (104) is not a
+            // valid outline level and must be rejected, not masked to `8`.
+            0x6412 => {
+                if let Some(&b) = sprm.operand.first() {
+                    if (1..=9).contains(&b) {
+                        props.heading_level = Some(b);
+                    }
+                }
+            },
             // sprmPChgTabs (0xC615) / sprmPChgTabsPapx (0xC60D): tab stops.
             0xC615 | 0xC60D => {
                 if !sprm.operand.is_empty() {
@@ -467,6 +504,50 @@ mod tests {
         assert_eq!(sprms[0].operand, vec![0x01]);
         assert_eq!(sprms[1].opcode, 0x6649);
         assert_eq!(sprms[1].operand, vec![0x01, 0x00, 0x00, 0x00]);
+    }
+
+    /// `sprmPOutlineLvl` (0x6412) is a spra-3 (4-byte) SPRM whose low byte is the
+    /// outline level: `1`–`9` = Heading 1–9. The level must surface on
+    /// `PapProps.heading_level`.
+    #[test]
+    fn sprm_p_outline_lvl_sets_heading_level() {
+        // opcode 0x6412 (LE) + 4-byte operand, low byte = 2 (valid level).
+        let grpprl = vec![0x12, 0x64, 0x02, 0x00, 0x00, 0x00];
+        let props = extract_pap_props(&grpprl);
+        assert_eq!(props.heading_level, Some(2), "outline level 2 -> Heading 2");
+    }
+
+    #[test]
+    fn sprm_p_outline_lvl_body_is_none() {
+        // outline level 0 means body text, not a heading.
+        let grpprl = vec![0x12, 0x64, 0x00, 0x00, 0x00, 0x00];
+        let props = extract_pap_props(&grpprl);
+        assert_eq!(props.heading_level, None, "outline level 0 -> not a heading");
+    }
+
+    /// A `sprmPOutlineLvl` operand whose low byte is outside 1–9 (here 0x68 =
+    /// 104) is not a valid outline level and must be ignored, even though the
+    /// opcode byte pattern appears in the grpprl. This guards against
+    /// coincidental byte sequences fabricating spurious headings.
+    #[test]
+    fn sprm_p_outline_lvl_rejects_invalid_byte() {
+        let grpprl = vec![0x12, 0x64, 0x68, 0x01, 0x01, 0x00];
+        let props = extract_pap_props(&grpprl);
+        assert_eq!(props.heading_level, None, "0x68 is not a valid outline level");
+    }
+
+    /// `sprmPStyle` (0x640A) overrides the PAPX `istd`; the 2-byte istd is the
+    /// low word of the (spra-3, 4-byte) operand.
+    #[test]
+    fn paragraph_style_istd_reads_override() {
+        // opcode 0x640A (LE) + 4-byte operand, low word = istd 5.
+        let grpprl = vec![0x0A, 0x64, 0x05, 0x00, 0x00, 0x00];
+        assert_eq!(paragraph_style_istd(&grpprl), Some(5));
+    }
+
+    #[test]
+    fn paragraph_style_istd_absent_when_no_sprm() {
+        assert_eq!(paragraph_style_istd(&[0x16, 0x24, 0x01]), None);
     }
 
     #[test]

--- a/src/doc/sprm.rs
+++ b/src/doc/sprm.rs
@@ -707,6 +707,44 @@ mod tests {
         );
     }
 
+    /// The `sprmPOutLvl` operand is **zero-based**: `0x00`–`0x08` are Heading
+    /// 1–9 and `0x09` is body text. Each edge is pinned separately, because an
+    /// off-by-one here is invisible in aggregate counts — it silently re-labels
+    /// every heading in every document by one level.
+    #[test]
+    fn sprm_p_out_lvl_zero_is_heading_one() {
+        let props = extract_pap_props(&[0x40, 0x26, 0x00]);
+        assert_eq!(props.outline_level, Some(0), "0x00 is Heading 1, not body text");
+        assert!(props.outline_lvl_explicit);
+    }
+
+    #[test]
+    fn sprm_p_out_lvl_eight_is_heading_nine() {
+        let props = extract_pap_props(&[0x40, 0x26, 0x08]);
+        assert_eq!(props.outline_level, Some(8), "0x08 is Heading 9");
+        assert!(props.outline_lvl_explicit);
+    }
+
+    #[test]
+    fn sprm_p_out_lvl_nine_is_body_text() {
+        let props = extract_pap_props(&[0x40, 0x26, 0x09]);
+        assert_eq!(props.outline_level, None, "0x09 means body text, not Heading 9");
+        assert!(
+            props.outline_lvl_explicit,
+            "body text must still settle the question, so the style is never consulted"
+        );
+    }
+
+    #[test]
+    fn sprm_p_out_lvl_above_nine_is_not_an_outline_level() {
+        let props = extract_pap_props(&[0x40, 0x26, 0x0A]);
+        assert_eq!(props.outline_level, None);
+        assert!(
+            !props.outline_lvl_explicit,
+            "an operand above 0x09 is not an outline level and must not settle anything"
+        );
+    }
+
     /// `sprmPIstd` (0x4600) overrides the PAPX `istd`; its operand is the 2-byte
     /// istd. It surfaces on `PapProps.style_istd` from the same grpprl walk that
     /// decodes the other paragraph properties.

--- a/src/doc/sprm.rs
+++ b/src/doc/sprm.rs
@@ -27,6 +27,11 @@
 
 use crate::ir::{TabAlignment, TabLeader, TabStop};
 
+/// The `sprmPOutLvl` (0x2640) operand value meaning "this paragraph is body
+/// text". The SPRM encodes the level zero-based, so 0x00–0x08 are Heading 1–9
+/// and this value — not 0 — is the body-text marker ([MS-DOC] §2.6.2).
+const OUTLVL_BODY_TEXT: u8 = 9;
+
 /// A single decoded SPRM: opcode plus its operand bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Sprm {
@@ -215,13 +220,38 @@ pub struct PapProps {
     /// list/tab-stop PR; in the tables-only PR this field is always empty, but
     /// it is cloned through the IR so the `Paragraph.tabs` shape stays uniform.
     pub tabs: Vec<TabStop>,
-    /// Outline level from `sprmPOutLvl` (0x2640), in [MS-DOC]'s value space:
-    /// `0` = Heading 1 … `8` = Heading 9, and `9` = body text. Stored only
-    /// for real heading levels (0–8); `9` and absent both leave this `None`.
+    /// Outline level, in [MS-DOC]'s value space: `0` = Heading 1 … `8` =
+    /// Heading 9, and `9` = body text. Stored only for real heading levels
+    /// (0–8); `9` and "nothing resolved" both leave this `None`.
     ///
     /// This is the evidence that a document has *real* heading structure,
     /// which is what gates the line-shape heading guess in `convert_doc`.
+    ///
+    /// It comes from either source, and is filled in two stages:
+    /// `extract_pap_props` sets it from `sprmPOutLvl` (0x2640) when that SPRM
+    /// is present; otherwise it stays `None` until `build_paragraphs` resolves
+    /// the paragraph's style (`istd`) into a level. So the value returned by
+    /// `extract_pap_props` alone is *not* necessarily final.
+    ///
+    /// Keeping one field rather than a parallel 1-based one is deliberate: two
+    /// fields encoding the same level at different offsets have to be kept in
+    /// step by hand, and a caller that sets only one of them silently loses the
+    /// level.
     pub outline_level: Option<u8>,
+    /// The style index this paragraph is restyled to by a direct `sprmPIstd`
+    /// (0x4600) in the grpprl, if any. It overrides the PAPX header's own
+    /// `istd` when resolving the style (see `crate::doc::styles`); `None` means
+    /// the PAPX header `istd` applies unchanged.
+    pub style_istd: Option<u16>,
+    /// True when the grpprl carries a `sprmPOutLvl` (0x2640) whose operand is a
+    /// valid outline level (0x00–0x09).
+    ///
+    /// This distinguishes "the SPRM is absent" from "the SPRM is present and
+    /// says body text" (operand 0x09): in both cases `outline_level` is `None`,
+    /// but only the latter settles the question — when this flag is set the
+    /// paragraph's style must not be consulted. An operand above 0x09 is not an
+    /// outline level at all, leaves this flag false, and is ignored.
+    pub outline_lvl_explicit: bool,
 }
 
 /// One table cell descriptor (TKBKTAP, 20 bytes) distilled from a row's
@@ -429,11 +459,32 @@ pap_sprm_dispatch! {
     /// 1-byte operand: 0..=8 are Heading 1..9 and 9 is body text.
     /// The opcode is 0x2640 — *not* the 0x6412 a byte-swapped reading
     /// suggests, which is `sprmPDyaLine`.
+    ///
+    /// `outline_lvl_explicit` records that the SPRM is present with a valid
+    /// operand, so "absent" and "present but body text" stay distinguishable:
+    /// only the latter suppresses a heading the paragraph's style would
+    /// otherwise give it. An operand above 9 is not an outline level at all,
+    /// leaves the flag false, and is ignored.
     "sprmPOutLvl" @ "2.6.2" => [0x2640] (props, operand) {
         if let Some(&lvl) = operand.first() {
-            if lvl <= 8 {
+            if lvl < OUTLVL_BODY_TEXT {
+                props.outline_lvl_explicit = true;
                 props.outline_level = Some(lvl);
+            } else if lvl == OUTLVL_BODY_TEXT {
+                // Explicitly body text: settle it, and never consult the style.
+                props.outline_lvl_explicit = true;
             }
+        }
+    }
+
+    /// 2-byte operand: the style index (`istd`) this paragraph is restyled to.
+    /// It overrides the PAPX header `istd` when the style is resolved.
+    ///
+    /// Not 0x640A: `ispmd` 0x0A is `sprmPIlvl` (0x260A), and 0x640A is not a
+    /// paragraph SPRM at all.
+    "sprmPIstd" @ "2.6.2" => [0x4600] (props, operand) {
+        if operand.len() >= 2 {
+            props.style_istd = Some(u16::from_le_bytes([operand[0], operand[1]]));
         }
     }
 
@@ -533,6 +584,7 @@ mod tests {
         (0x2417, "sprmPFTtp"),
         (0x260A, "sprmPIlvl"),
         (0x2640, "sprmPOutLvl"),
+        (0x4600, "sprmPIstd"),
         (0x460B, "sprmPIlfo"),
         (0x6412, "sprmPDyaLine"),
         (0x6649, "sprmPItap"),
@@ -638,6 +690,36 @@ mod tests {
         assert_eq!(sprms[0].operand, vec![0x01]);
         assert_eq!(sprms[1].opcode, 0x6649);
         assert_eq!(sprms[1].operand, vec![0x01, 0x00, 0x00, 0x00]);
+    }
+
+    /// Regression: 0x6412 is **sprmPDyaLine** (line spacing), not an outline
+    /// level. An earlier revision read its low byte as one, so ordinary line
+    /// spacing turned body paragraphs into headings. 0x6412 occurs 758 times in
+    /// the POI corpus, all of it line spacing, so this must stay inert.
+    #[test]
+    fn sprm_p_dya_line_is_not_read_as_an_outline_level() {
+        // LSPD: dyaLine = 0x0005, fMultLinespace = 0x0000.
+        let props = extract_pap_props(&[0x12, 0x64, 0x05, 0x00, 0x00, 0x00]);
+        assert_eq!(props.outline_level, None, "line spacing must never become an outline level");
+        assert!(
+            !props.outline_lvl_explicit,
+            "line spacing must not settle the outline level either"
+        );
+    }
+
+    /// `sprmPIstd` (0x4600) overrides the PAPX `istd`; its operand is the 2-byte
+    /// istd. It surfaces on `PapProps.style_istd` from the same grpprl walk that
+    /// decodes the other paragraph properties.
+    #[test]
+    fn pap_props_read_sprm_p_istd_override() {
+        // opcode 0x4600 (LE) + 2-byte operand = istd 5.
+        let grpprl = vec![0x00, 0x46, 0x05, 0x00];
+        assert_eq!(extract_pap_props(&grpprl).style_istd, Some(5));
+    }
+
+    #[test]
+    fn pap_props_style_istd_absent_when_no_sprm() {
+        assert_eq!(extract_pap_props(&[0x16, 0x24, 0x01]).style_istd, None);
     }
 
     #[test]

--- a/src/doc/styles.rs
+++ b/src/doc/styles.rs
@@ -268,4 +268,63 @@ mod tests {
         assert!(parse_stsh(&[0u8; 4]).is_empty());
         assert!(parse_stsh(&[18, 0, 0, 0]).is_empty());
     }
+
+    /// Build a `Fib` whose only non-zero fields are `fc_stshf` / `lcb_stshf`,
+    /// pointing at a style sheet in the Table stream.
+    fn fib_with_stsh(start: u32, len: u32) -> Fib {
+        Fib {
+            version: 0,
+            use_table1: false,
+            clx_offset: 0,
+            clx_size: 0,
+            text_len: 0,
+            footnote_len: 0,
+            header_len: 0,
+            comment_len: 0,
+            endnote_len: 0,
+            textbox_len: 0,
+            header_textbox_len: 0,
+            fc_plcf_bte_papx: 0,
+            lcb_plcf_bte_papx: 0,
+            fc_plcf_lst: 0,
+            lcb_plcf_lst: 0,
+            fc_stshf: start,
+            lcb_stshf: len,
+        }
+    }
+
+    /// `parse_style_sheet` is the FIB-aware wrapper that `document.rs` calls: it
+    /// must slice the STSH out of the Table stream at `fc_stshf` (bounds-checked)
+    /// and hand the bytes to `parse_stsh`. This exercises the wrapper end-to-end
+    /// with real STSH bytes placed at a non-zero offset — the path the POI corpus
+    /// never reaches (every file reports `fc_stshf == 0`).
+    #[test]
+    fn parse_style_sheet_reads_stsh_at_fib_offset() {
+        let stsh = synthetic_stsh();
+        let start = 64usize;
+        let mut table_stream = vec![0u8; start + stsh.len()];
+        table_stream[start..start + stsh.len()].copy_from_slice(&stsh);
+        let fib = fib_with_stsh(start as u32, stsh.len() as u32);
+        let styles = parse_style_sheet(&table_stream, &fib);
+        assert_eq!(styles.len(), 3);
+        assert_eq!(styles[0].sti, 0);
+        assert_eq!(styles[0].name, "Normal");
+        assert_eq!(styles[1].sti, 1);
+        assert_eq!(styles[1].name, "Heading 1");
+        assert_eq!(styles[2].sti, 0x0FFE);
+        assert_eq!(styles[2].name, "Heading 2");
+    }
+
+    #[test]
+    fn parse_style_sheet_absent_is_empty() {
+        let table_stream = vec![0u8; 64];
+        assert!(parse_style_sheet(&table_stream, &fib_with_stsh(0, 0)).is_empty());
+    }
+
+    #[test]
+    fn parse_style_sheet_out_of_bounds_is_empty() {
+        let stsh = synthetic_stsh();
+        // Point `fc_stshf` past the end of the table stream.
+        assert!(parse_style_sheet(&stsh, &fib_with_stsh(1000, stsh.len() as u32)).is_empty());
+    }
 }

--- a/src/doc/styles.rs
+++ b/src/doc/styles.rs
@@ -30,7 +30,13 @@ pub fn parse_style_sheet(table_stream: &[u8], fib: &Fib) -> Vec<StyleDef> {
         return Vec::new();
     }
     let start = fib.fc_stshf as usize;
-    let end = (start + fib.lcb_stshf as usize).min(table_stream.len());
+    // `saturating_add` so a malformed `fc_stshf`/`lcb_stshf` (e.g. near
+    // `u32::MAX`) cannot overflow the pointer arithmetic on 32-bit targets;
+    // on 64-bit the sum already fits, but the contract is "no overflow, ever"
+    // (AGENTS.md rule 6).
+    let end = start
+        .saturating_add(fib.lcb_stshf as usize)
+        .min(table_stream.len());
     if start >= table_stream.len() || end <= start {
         return Vec::new();
     }

--- a/src/doc/styles.rs
+++ b/src/doc/styles.rs
@@ -1,0 +1,271 @@
+//! Style sheet (STSH) parsing for legacy binary `.doc` (MS-DOC §2.7.1).
+//!
+//! The style sheet maps a paragraph's style index (`istd`) to a built-in
+//! style id (`sti`) and a name. Built-in heading styles carry `sti` 1–9
+//! (Heading 1–9); user-defined heading styles are named `Heading N`. Both let
+//! us derive a paragraph's real heading level instead of the line heuristic in
+//! `convert_doc.rs`.
+//!
+//! Every parse step is bounds-checked: a malformed or truncated style sheet
+//! yields an empty `Vec`, so callers degrade to "no style" (and the heuristic)
+//! rather than panicking (AGENTS.md rule 6).
+
+use super::fib::Fib;
+
+/// One style definition, indexed by `istd`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StyleDef {
+    /// Built-in style id (`StdfBase.sti`). `0x0FFE` means user-defined.
+    pub sti: u16,
+    /// Style name (from the style-name STTB).
+    pub name: String,
+}
+
+/// Parse the document style sheet (STSH) from the Table stream.
+///
+/// Returns an empty vector when the style sheet is absent (`fcStshf == 0`),
+/// out of bounds, or malformed.
+pub fn parse_style_sheet(table_stream: &[u8], fib: &Fib) -> Vec<StyleDef> {
+    if fib.fc_stshf == 0 || fib.lcb_stshf == 0 {
+        return Vec::new();
+    }
+    let start = fib.fc_stshf as usize;
+    let end = (start + fib.lcb_stshf as usize).min(table_stream.len());
+    if start >= table_stream.len() || end <= start {
+        return Vec::new();
+    }
+    parse_stsh(&table_stream[start..end])
+}
+
+/// Resolve a paragraph's `istd` (optionally overridden by `sprmPStyle`) to a
+/// heading level (1–9), or `None` when the style is not a heading.
+pub fn heading_level_for_istd(styles: &[StyleDef], istd: u16) -> Option<u8> {
+    let s = styles.get(istd as usize)?;
+    // Built-in heading styles: `sti` 1..9 == Heading 1..9.
+    if (1..=9).contains(&s.sti) {
+        return Some(s.sti as u8);
+    }
+    // User-defined heading styles are named "Heading N".
+    if let Some(level) = heading_level_from_name(&s.name) {
+        return Some(level);
+    }
+    None
+}
+
+fn heading_level_from_name(name: &str) -> Option<u8> {
+    // Real Word style names are "Heading N" (capital H); match case-insensitively
+    // so "heading 2" / "HEADING 2" also resolve.
+    let lowered: String = name.trim().to_ascii_lowercase();
+    let rest = lowered.strip_prefix("heading ")?;
+    let level: u8 = rest.trim().parse().ok()?;
+    if (1..=9).contains(&level) {
+        Some(level)
+    } else {
+        None
+    }
+}
+
+/// `data` is the `stshf` slice (the STSH). Layout (MS-DOC §2.7.1):
+/// `cbStshi(u16)` + `Stshif(cbStshi)` + style-name `STTB` + `cstd` `LPStd`
+/// (each `cbStd(u16)` + `Stdf`).
+fn parse_stsh(data: &[u8]) -> Vec<StyleDef> {
+    // `cbStshi` then `Stshif`.
+    if data.len() < 2 {
+        return Vec::new();
+    }
+    let cb_stshi = u16::from_le_bytes([data[0], data[1]]) as usize;
+    let mut pos = 2;
+    if cb_stshi < 18 || pos + cb_stshi > data.len() {
+        return Vec::new();
+    }
+    // Stshif: `cstd` at offset 0 (u16).
+    let cstd = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+    pos += cb_stshi;
+
+    // Style-name STTB.
+    let (names, next) = match parse_sttb(data, pos) {
+        Some(v) => v,
+        None => return Vec::new(),
+    };
+    pos = next;
+
+    // Style-definition array: `cstd` `LPStd` entries, each `cbStd(u16)` + `Stdf`.
+    let cap = cstd.min(4096);
+    let mut styles = Vec::with_capacity(cap);
+    for _ in 0..cap {
+        if pos + 2 > data.len() {
+            break;
+        }
+        let cb_std = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+        pos += 2;
+        if cb_std == 0 {
+            // Empty style (fixed-index slots MAY be empty).
+            styles.push(StyleDef::default());
+            continue;
+        }
+        if pos + cb_std > data.len() {
+            break;
+        }
+        let std = &data[pos..pos + cb_std];
+        pos += cb_std;
+        // `StdfBase.sti` is the low 12 bits of the first u16.
+        let sti = if std.len() >= 2 {
+            u16::from_le_bytes([std[0], std[1]]) & 0x0FFF
+        } else {
+            0
+        };
+        styles.push(StyleDef {
+            sti,
+            name: String::new(),
+        });
+    }
+
+    // Names and definitions are both indexed by `istd`; attach by index.
+    for (i, s) in styles.iter_mut().enumerate() {
+        if let Some(n) = names.get(i) {
+            s.name = n.clone();
+        }
+    }
+    styles
+}
+
+/// Parse an `STTB` (§2.4.1) starting at `pos`, returning the strings and the
+/// offset just past the table (including its trailing null entry).
+fn parse_sttb(data: &[u8], mut pos: usize) -> Option<(Vec<String>, usize)> {
+    if pos + 3 > data.len() {
+        return None;
+    }
+    let f2 = data[pos]; // 1 => 2-byte counts, 0 => 1-byte counts
+    pos += 1;
+    let c_data = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+    pos += 2;
+    let count_len = if f2 != 0 { 2 } else { 1 };
+    let (cb_data, mut pos) = if f2 != 0 {
+        (u16::from_le_bytes([data[pos], data[pos + 1]]) as usize, pos + 2)
+    } else {
+        (data[pos] as usize, pos + 1)
+    };
+
+    let cap = c_data.min(4096);
+    let mut names = Vec::with_capacity(cap);
+    for _ in 0..cap {
+        if pos + count_len > data.len() {
+            return None;
+        }
+        let cch = if f2 != 0 {
+            let v = u16::from_le_bytes([data[pos], data[pos + 1]]);
+            pos += 2;
+            v as usize
+        } else {
+            let v = data[pos];
+            pos += 1;
+            v as usize
+        };
+        let str_bytes = cch.saturating_mul(2);
+        if pos + str_bytes > data.len() {
+            return None;
+        }
+        let units: Vec<u16> = (0..cch)
+            .map(|i| u16::from_le_bytes([data[pos + 2 * i], data[pos + 2 * i + 1]]))
+            .collect();
+        pos += str_bytes;
+        if pos + cb_data > data.len() {
+            return None;
+        }
+        pos += cb_data; // skip per-entry extra data
+        names.push(String::from_utf16_lossy(&units));
+    }
+
+    // Trailing null string entry (cch = 0).
+    if pos + count_len <= data.len() {
+        pos += count_len;
+    }
+    Some((names, pos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal but well-formed STSH: 3 styles — `Normal` (sti 0),
+    /// `Body Text` (sti 2), and a user-defined `Heading 2` (sti 0x0FFE).
+    fn synthetic_stsh() -> Vec<u8> {
+        let mut d = Vec::new();
+        // cbStshi = 18
+        d.extend_from_slice(&18u16.to_le_bytes());
+        // Stshif: cstd = 3, cbSTDBaseInFile = 10, rest 0.
+        d.extend_from_slice(&3u16.to_le_bytes());
+        d.extend_from_slice(&10u16.to_le_bytes());
+        d.extend_from_slice(&[0u8; 14]); // remainder of the 18-byte Stshif
+
+        // Style-name STTB (f2 = 1, cData = 3, cbData = 0).
+        d.push(1); // f2
+        d.extend_from_slice(&3u16.to_le_bytes()); // cData
+        d.extend_from_slice(&0u16.to_le_bytes()); // cbData
+        // entry 0: "Normal"
+        let name0 = "Normal";
+        d.extend_from_slice(&(name0.len() as u16).to_le_bytes());
+        for c in name0.encode_utf16() {
+            d.extend_from_slice(&c.to_le_bytes());
+        }
+        // entry 1: "Heading 1"
+        let name1 = "Heading 1";
+        d.extend_from_slice(&(name1.len() as u16).to_le_bytes());
+        for c in name1.encode_utf16() {
+            d.extend_from_slice(&c.to_le_bytes());
+        }
+        // entry 2: "Heading 2"
+        let name2 = "Heading 2";
+        d.extend_from_slice(&(name2.len() as u16).to_le_bytes());
+        for c in name2.encode_utf16() {
+            d.extend_from_slice(&c.to_le_bytes());
+        }
+        // trailing null string (cch = 0, 2 bytes)
+        d.extend_from_slice(&0u16.to_le_bytes());
+
+        // `cstd` = 3 LPStd entries, each cbStd = 10 + StdfBase.
+        // entry 0: sti = 0 (Normal)
+        d.extend_from_slice(&10u16.to_le_bytes());
+        d.extend_from_slice(&[0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0]);
+        // entry 1: sti = 1 (built-in Heading 1)
+        d.extend_from_slice(&10u16.to_le_bytes());
+        d.extend_from_slice(&[0x01, 0x00, 0, 0, 0, 0, 0, 0, 0, 0]);
+        // entry 2: sti = 0x0FFE (user-defined heading, name carries the level)
+        d.extend_from_slice(&10u16.to_le_bytes());
+        d.extend_from_slice(&[0xFE, 0x0F, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+        d
+    }
+
+    #[test]
+    fn parse_stsh_reads_sti_and_names() {
+        let styles = parse_stsh(&synthetic_stsh());
+        assert_eq!(styles.len(), 3);
+        assert_eq!(styles[0].sti, 0);
+        assert_eq!(styles[0].name, "Normal");
+        assert_eq!(styles[1].sti, 1);
+        assert_eq!(styles[1].name, "Heading 1");
+        // User-defined heading: sti 0x0FFE, name "Heading 2".
+        assert_eq!(styles[2].sti, 0x0FFE);
+        assert_eq!(styles[2].name, "Heading 2");
+    }
+
+    #[test]
+    fn heading_level_resolves_builtin_and_user() {
+        let styles = parse_stsh(&synthetic_stsh());
+        // sti 1..9 resolve directly.
+        assert_eq!(heading_level_for_istd(&styles, 1), Some(1));
+        // sti 0x0FFE named "Heading 2" resolves via name.
+        assert_eq!(heading_level_for_istd(&styles, 2), Some(2));
+        // sti 0 (Normal) is not a heading.
+        assert_eq!(heading_level_for_istd(&styles, 0), None);
+        // out-of-range istd.
+        assert_eq!(heading_level_for_istd(&styles, 99), None);
+    }
+
+    #[test]
+    fn truncated_style_sheet_is_empty() {
+        assert!(parse_stsh(&[0u8; 4]).is_empty());
+        assert!(parse_stsh(&[18, 0, 0, 0]).is_empty());
+    }
+}

--- a/src/doc/styles.rs
+++ b/src/doc/styles.rs
@@ -1,0 +1,598 @@
+//! Style sheet (STSH) parsing for legacy binary `.doc` (MS-DOC §2.7.1).
+//!
+//! The style sheet maps a paragraph's style index (`istd`) to a built-in
+//! style id (`sti`) and a name. Built-in heading styles carry `sti` 1–9
+//! (Heading 1–9); user-defined heading styles are named `Heading N`. Both let
+//! us derive a paragraph's real heading level instead of the line heuristic in
+//! `convert_doc.rs`.
+//!
+//! Every parse step is bounds-checked: a malformed or truncated style sheet
+//! yields an empty `Vec`, so callers degrade to "no style" (and the heuristic)
+//! rather than panicking (AGENTS.md rule 6).
+
+use super::{MAX_OUTLINE_LEVEL, fib::Fib};
+
+/// One style definition, indexed by `istd`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StyleDef {
+    /// Built-in style id (`StdfBase.sti`). `0x0FFE` means user-defined.
+    pub sti: u16,
+    /// Style name (from the style-name STTB).
+    pub name: String,
+}
+
+/// Parse the document style sheet (STSH) from the Table stream.
+///
+/// Returns an empty vector when the style sheet is absent (`lcbStshf == 0`),
+/// out of bounds, or malformed.
+///
+/// Only the *length* is a valid absence test. `fcStshf` is an offset into
+/// the Table stream and `0` is the usual value, because the style sheet is
+/// normally the first thing written there; [MS-DOC] `FibRgFcLcb97` requires
+/// `lcbStshf` to be non-zero and `STSH` states every FIB contains a style
+/// sheet. Testing the offset silently discarded the style sheet of nearly
+/// every real document.
+pub fn parse_style_sheet(table_stream: &[u8], fib: &Fib) -> Vec<StyleDef> {
+    // Guard on the length only: `fc_stshf` is an offset and 0 is its normal
+    // value, so treating 0 as "absent" drops real style sheets.
+    if fib.lcb_stshf == 0 {
+        return Vec::new();
+    }
+    let start = fib.fc_stshf as usize;
+    // `saturating_add` so a malformed `fc_stshf`/`lcb_stshf` (e.g. near
+    // `u32::MAX`) cannot overflow the pointer arithmetic on 32-bit targets;
+    // on 64-bit the sum already fits, but the contract is "no overflow, ever"
+    // (AGENTS.md rule 6).
+    let end = start
+        .saturating_add(fib.lcb_stshf as usize)
+        .min(table_stream.len());
+    if start >= table_stream.len() || end <= start {
+        return Vec::new();
+    }
+    parse_stsh(&table_stream[start..end])
+}
+
+/// Resolve a paragraph's `istd` (optionally overridden by `sprmPIstd`) to a
+/// heading level (1–9), or `None` when the style is not a heading.
+pub fn heading_level_for_istd(styles: &[StyleDef], istd: u16) -> Option<u8> {
+    let s = styles.get(istd as usize)?;
+    // Built-in heading styles: `sti` 1..9 == Heading 1..9.
+    if (1..=u16::from(MAX_OUTLINE_LEVEL)).contains(&s.sti) {
+        return Some(s.sti as u8);
+    }
+    // User-defined heading styles are named "Heading N".
+    if let Some(level) = heading_level_from_name(&s.name) {
+        return Some(level);
+    }
+    None
+}
+
+fn heading_level_from_name(name: &str) -> Option<u8> {
+    // Real Word style names are "Heading N" (capital H); match case-insensitively
+    // so "heading 2" / "HEADING 2" also resolve.
+    //
+    // `xstzName` may carry aliases as "primary,alias,alias" (MS-DOC §2.9.258);
+    // a heading level is always carried by the primary name, so look at the
+    // segment before the first comma.
+    //
+    // Matched **without allocating**: this is the fallback for every paragraph
+    // whose style is not a built-in `sti` 1–9 heading, so a
+    // `to_ascii_lowercase()` here would cost one `String` per paragraph in the
+    // document. The empty name is the common case (fixed-index slots), and
+    // fails the length check immediately.
+    const PREFIX: &[u8] = b"heading ";
+    let primary = name.split(',').next().unwrap_or("").trim();
+    if primary.len() < PREFIX.len()
+        || !primary.as_bytes()[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+    {
+        return None;
+    }
+    let level: u8 = primary[PREFIX.len()..].trim().parse().ok()?;
+    if (1..=MAX_OUTLINE_LEVEL).contains(&level) {
+        Some(level)
+    } else {
+        None
+    }
+}
+
+/// `data` is the `stshf` slice (the STSH). Layout (MS-DOC §2.9.271):
+/// `LPStshi` = `cbStshi(u16)` + `Stshif(cbStshi bytes)`, immediately followed by
+/// `rglpstd`, an array of `cstd` `LPStd` entries (`cbStd(u16)` + `STD`).
+///
+/// There is **no** style-name table between `Stshif` and `rglpstd`: `Stshif` is
+/// exactly 18 bytes and carries no names (§2.9.274). Each style's name lives
+/// inside its own `STD`, which is `stdf` + `xstzName` + `grLPUpxSw` (§2.9.258),
+/// and `stdf` occupies `cbSTDBaseInFile` bytes.
+fn parse_stsh(data: &[u8]) -> Vec<StyleDef> {
+    if data.len() < 2 {
+        return Vec::new();
+    }
+    let cb_stshi = u16::from_le_bytes([data[0], data[1]]) as usize;
+    let mut pos = 2;
+    if cb_stshi < 18 || pos + cb_stshi > data.len() {
+        return Vec::new();
+    }
+    // Stshif (§2.9.274): `cstd` at 0 (u16), `cbSTDBaseInFile` at 2 (u16).
+    let cstd = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+    let cb_std_base = u16::from_le_bytes([data[pos + 2], data[pos + 3]]) as usize;
+    pos += cb_stshi;
+
+    // `cbSTDBaseInFile` MUST be 0x000A (`StdfBase` alone) or 0x0012 (`StdfBase`
+    // + `StdfPost2000OrNone`) per §2.9.274. Anything else is malformed: slicing
+    // `xstzName` at a bogus offset would yield plausible-but-wrong names, and
+    // hence plausible-but-wrong heading levels, so reject and let the caller
+    // degrade to the line heuristic rather than guess (AGENTS.md rule: fail
+    // loudly, never fall back to a silent plausible-but-wrong result).
+    if cb_std_base != 0x000A && cb_std_base != 0x0012 {
+        return Vec::new();
+    }
+
+    // `rglpstd`: `cstd` `LPStd` entries (§2.9.135).
+    let cap = cstd.min(4096);
+    let mut styles = Vec::with_capacity(cap);
+    for _ in 0..cap {
+        if pos + 2 > data.len() {
+            break;
+        }
+        let cb_std = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
+        pos += 2;
+        if cb_std == 0 {
+            // Empty style (fixed-index slots MAY be empty, §2.9.271).
+            styles.push(StyleDef::default());
+            continue;
+        }
+        if pos + cb_std > data.len() {
+            break;
+        }
+        let std = &data[pos..pos + cb_std];
+        // `StdfBase.sti` is the low 12 bits of the first u16 (§2.9.260).
+        let sti = if std.len() >= 2 {
+            u16::from_le_bytes([std[0], std[1]]) & 0x0FFF
+        } else {
+            0
+        };
+        // The name follows `stdf`, which occupies `cbSTDBaseInFile` bytes.
+        let name = if std.len() > cb_std_base {
+            parse_xstz(&std[cb_std_base..]).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        styles.push(StyleDef { sti, name });
+        pos += cb_std;
+        // LPStd entries are stored on even-byte boundaries and `cbStd` does NOT
+        // include that padding byte (§2.9.135).
+        if !cb_std.is_multiple_of(2) {
+            pos += 1;
+        }
+    }
+    styles
+}
+
+/// Parse an `Xstz` (§2.9.354) — a style name: an `Xst` (a `cch: u16` followed
+/// by `cch` UTF-16 code units) plus a 2-byte null terminator.
+///
+/// Per §2.9.258 the name may be `"primary,alias,alias"`; callers that want only
+/// the primary name split on `','` themselves (`heading_level_from_name` does).
+fn parse_xstz(data: &[u8]) -> Option<String> {
+    if data.len() < 2 {
+        return None;
+    }
+    let cch = u16::from_le_bytes([data[0], data[1]]) as usize;
+    let end = 2usize.saturating_add(cch.saturating_mul(2));
+    if end > data.len() {
+        return None;
+    }
+    let units: Vec<u16> = (0..cch)
+        .map(|i| u16::from_le_bytes([data[2 + 2 * i], data[3 + 2 * i]]))
+        .collect();
+    Some(String::from_utf16_lossy(&units))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build one `LPStd` for a style sheet: `cbStd(u16)` + `STD`.
+    ///
+    /// `STD` = `stdf` (`cbSTDBaseInFile` bytes, here `StdfBase` alone) +
+    /// `xstzName`, per MS-DOC §2.9.258. `xstzName` is an `Xstz`: `cch(u16)` +
+    /// `cch` UTF-16 code units + a 2-byte null terminator (§2.9.354).
+    fn lpstd(sti: u16, name: &str) -> Vec<u8> {
+        const CB_STD_BASE: usize = 0x000A;
+        // `StdfBase` (10 bytes): `sti` is the low 12 bits of the first u16.
+        let mut std = vec![0u8; CB_STD_BASE];
+        std[0..2].copy_from_slice(&sti.to_le_bytes());
+        // `xstzName`.
+        let units: Vec<u16> = name.encode_utf16().collect();
+        std.extend_from_slice(&(units.len() as u16).to_le_bytes()); // cch
+        for u in &units {
+            std.extend_from_slice(&u.to_le_bytes());
+        }
+        std.extend_from_slice(&0u16.to_le_bytes()); // chTerm
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&(std.len() as u16).to_le_bytes()); // cbStd
+        out.extend_from_slice(&std);
+        out
+    }
+
+    /// An empty `LPStd` (`cbStd` = 0). Fixed-index slots 13–14 MUST be empty
+    /// (§2.9.271) and 0–12 MAY be.
+    fn empty_lpstd() -> Vec<u8> {
+        vec![0, 0]
+    }
+
+    /// Build a spec-conformant STSH (§2.9.271 / §2.9.274): `LPStshi`
+    /// (`cbStshi` = 18 + an 18-byte `Stshif`) followed directly by `rglpstd`.
+    ///
+    /// The 16 entries follow the fixed-index table: istd 0 = Normal (sti 0),
+    /// istd 1–9 = Heading 1–9 (sti 1–9), istd 10–12 = sti 65/105/107, istd
+    /// 13–14 empty, and istd 15 a user-defined style (sti 0x0FFE) whose name
+    /// carries its level. Deliberately built from the spec, not from our
+    /// parser, so it cannot merely re-encode our own bugs.
+    fn synthetic_stsh() -> Vec<u8> {
+        let mut d = Vec::new();
+        // ── LPStshi: cbStshi, then Stshif (18 bytes total, no names) ──
+        d.extend_from_slice(&18u16.to_le_bytes()); // cbStshi = 18
+        d.extend_from_slice(&16u16.to_le_bytes()); // cstd
+        d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile = 10
+        d.extend_from_slice(&[0u8; 2]); // fStdStylenamesWritten + fReserved
+        d.extend_from_slice(&108u16.to_le_bytes()); // stiMaxWhenSaved
+        d.extend_from_slice(&0x000Fu16.to_le_bytes()); // istdMaxFixedWhenSaved
+        d.extend_from_slice(&0u16.to_le_bytes()); // nVerBuiltInNamesWhenSaved
+        d.extend_from_slice(&[0u8; 6]); // ftcAsci, ftcFE, ftcOther
+
+        // ── rglpstd ──
+        d.extend_from_slice(&lpstd(0, "Normal")); // istd 0
+        for lvl in 1..=9u16 {
+            d.extend_from_slice(&lpstd(lvl, &format!("Heading {lvl}"))); // 1–9
+        }
+        d.extend_from_slice(&lpstd(65, "Fixed Ten")); // istd 10
+        d.extend_from_slice(&lpstd(105, "Fixed Eleven")); // istd 11
+        d.extend_from_slice(&lpstd(107, "Fixed Twelve")); // istd 12
+        d.extend_from_slice(&empty_lpstd()); // istd 13 — MUST be empty
+        d.extend_from_slice(&empty_lpstd()); // istd 14 — MUST be empty
+        d.extend_from_slice(&lpstd(0x0FFE, "heading 7")); // istd 15: user style
+        d
+    }
+
+    #[test]
+    fn parse_stsh_reads_sti_and_names() {
+        let styles = parse_stsh(&synthetic_stsh());
+        assert_eq!(styles.len(), 16, "all 16 LPStd entries must be decoded");
+        // istd 0: Normal.
+        assert_eq!(styles[0].sti, 0);
+        assert_eq!(styles[0].name, "Normal");
+        // istd 1..9: built-in Heading 1..9 — names come from each STD, not
+        // from any shared table.
+        assert_eq!(styles[1].sti, 1);
+        assert_eq!(styles[1].name, "Heading 1");
+        assert_eq!(styles[3].sti, 3);
+        assert_eq!(styles[3].name, "Heading 3");
+        assert_eq!(styles[9].sti, 9);
+        assert_eq!(styles[9].name, "Heading 9");
+        // istd 13/14 are empty.
+        assert_eq!(styles[13], StyleDef::default());
+        assert_eq!(styles[14], StyleDef::default());
+        // istd 15: user-defined (sti 0x0FFE), name carries the level.
+        assert_eq!(styles[15].sti, 0x0FFE);
+        assert_eq!(styles[15].name, "heading 7");
+    }
+
+    /// Regression guard: an earlier revision decoded the style sheet as
+    /// `cbStshi + Stshif + a style-name STTB + rglpstd`. That is wrong —
+    /// `Stshif` is exactly 18 bytes and carries no names, and `rglpstd`
+    /// follows immediately (§2.9.271); names live in each `STD.xstzName`.
+    /// A style sheet laid out the old way must not be silently decoded into
+    /// plausible-but-wrong style names: it must yield nothing, so the caller
+    /// degrades to the line heuristic instead of inventing heading levels.
+    #[test]
+    fn parse_stsh_rejects_spurious_name_table_layout() {
+        let mut d = Vec::new();
+        d.extend_from_slice(&18u16.to_le_bytes()); // cbStshi
+        d.extend_from_slice(&4u16.to_le_bytes()); // cstd
+        d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile
+        d.extend_from_slice(&[0u8; 14]); // rest of Stshif
+        // The spurious style-name "STTB" that the old revision expected.
+        d.push(1); // f2
+        d.extend_from_slice(&4u16.to_le_bytes()); // cData
+        d.extend_from_slice(&0u16.to_le_bytes()); // cbData
+        for name in ["Normal", "", "", "Heading 3"] {
+            let units: Vec<u16> = name.encode_utf16().collect();
+            d.extend_from_slice(&(units.len() as u16).to_le_bytes());
+            for u in units {
+                d.extend_from_slice(&u.to_le_bytes());
+            }
+        }
+        d.extend_from_slice(&0u16.to_le_bytes()); // trailing null cch
+        for &sti in &[0u16, 0u16, 0u16, 3u16] {
+            d.extend_from_slice(&10u16.to_le_bytes()); // cbStd
+            d.extend_from_slice(&sti.to_le_bytes());
+            d.extend_from_slice(&[0u8; 8]);
+        }
+
+        // An earlier version of this assertion was vacuous: it ran `.all()` over
+        // an empty vector, which holds for any implementation. What actually
+        // has to be pinned is the *behaviour* — these bytes must not keep
+        // producing a Heading 3, which they did when names were attached by
+        // index from that table.
+        let styles = parse_stsh(&d);
+        assert!(
+            heading_level_for_istd(&styles, 3).is_none(),
+            "a spurious name table must not keep yielding Heading 3; got {styles:?}"
+        );
+        // Contrast, so the line above cannot pass by doing nothing: the same
+        // intent expressed in the spec layout does resolve.
+        assert_eq!(
+            heading_level_for_istd(&parse_stsh(&synthetic_stsh()), 3),
+            Some(3),
+            "the spec layout must still resolve istd 3 to Heading 3"
+        );
+    }
+
+    /// The name must be read from `STD.xstzName`, i.e. at `cbSTDBaseInFile`
+    /// bytes into each `STD`. A fixture that shifts the name by even one byte
+    /// must not silently produce a plausible-but-wrong name.
+    #[test]
+    fn parse_stsh_rejects_unexpected_cb_std_base_in_file() {
+        let mut stsh = synthetic_stsh();
+        // `cbSTDBaseInFile` is the u16 at offset 4 (cbStshi + cstd). Spec allows
+        // only 0x000A / 0x0012; anything else is malformed.
+        stsh[4..6].copy_from_slice(&0x0020u16.to_le_bytes());
+        assert!(
+            parse_stsh(&stsh).is_empty(),
+            "a bogus cbSTDBaseInFile must be rejected, not guess a name offset"
+        );
+    }
+
+    /// `LPStd` entries sit on even-byte boundaries and `cbStd` excludes the
+    /// padding byte (§2.9.135), so an odd-sized `STD` must not desynchronise the
+    /// following entries.
+    #[test]
+    fn parse_stsh_skips_odd_sized_lpstd_padding() {
+        let mut stsh = synthetic_stsh();
+        // Rebuild rglpstd: one odd-sized entry, then a normal one.
+        let mut rglpstd = Vec::new();
+        let mut odd = lpstd(2, "Heading 2");
+        // Trim one byte off `STD` (and fix up cbStd) to make cbStd odd.
+        let cb = u16::from_le_bytes([odd[0], odd[1]]) as usize;
+        odd.truncate(cb + 1); // 2 (cbStd) + cb-1 bytes of STD
+        let new_cb = (cb - 1) as u16;
+        odd[0..2].copy_from_slice(&new_cb.to_le_bytes());
+        rglpstd.extend_from_slice(&odd);
+        rglpstd.push(0x00); // the padding byte `cbStd` does not count
+        rglpstd.extend_from_slice(&lpstd(3, "Heading 3"));
+        stsh.truncate(20); // keep cbStshi + Stshif
+        stsh.extend_from_slice(&rglpstd);
+
+        let styles = parse_stsh(&stsh);
+        assert_eq!(styles.len(), 2, "both entries must be read");
+        assert_eq!(styles[0].sti, 2, "odd-sized entry decodes normally");
+        assert_eq!(
+            styles[1].name, "Heading 3",
+            "the padding byte must not desynchronise the next entry"
+        );
+    }
+
+    #[test]
+    fn heading_level_resolves_builtin_and_user() {
+        let styles = parse_stsh(&synthetic_stsh());
+        // Built-in: sti 1..9 resolve directly (istd 1..9).
+        assert_eq!(heading_level_for_istd(&styles, 1), Some(1));
+        assert_eq!(heading_level_for_istd(&styles, 3), Some(3));
+        assert_eq!(heading_level_for_istd(&styles, 9), Some(9));
+        // User-defined: sti 0x0FFE named "heading 7" resolves via name.
+        assert_eq!(heading_level_for_istd(&styles, 15), Some(7));
+        // sti 0 (Normal) is not a heading.
+        assert_eq!(heading_level_for_istd(&styles, 0), None);
+        // Empty fixed-index slots are not headings.
+        assert_eq!(heading_level_for_istd(&styles, 13), None);
+        // out-of-range istd.
+        assert_eq!(heading_level_for_istd(&styles, 99), None);
+    }
+
+    /// The built-in `sti` must resolve a heading on its own, without help from
+    /// the name. Real Word documents localise the built-in style names — German
+    /// "Überschrift 3", French "Titre 3" — and those carry `sti` 1-9 while not
+    /// matching `heading N` at all. Without the `sti` branch such a document
+    /// would lose every heading.
+    ///
+    /// This also pins the branch against being masked: every other fixture names
+    /// its styles "Heading N", so the name-based path alone would satisfy them.
+    #[test]
+    fn heading_level_resolves_localized_builtin_style_via_sti() {
+        let styles = vec![
+            StyleDef::default(), // istd 0
+            StyleDef {
+                sti: 3,
+                name: "\u{00dc}berschrift 3".into(),
+            }, // istd 1 (de)
+            StyleDef {
+                sti: 5,
+                name: "Titre 5".into(),
+            }, // istd 2 (fr)
+            StyleDef {
+                sti: 0x0FFE,
+                name: "Custom".into(),
+            }, // istd 3
+        ];
+        assert_eq!(heading_level_for_istd(&styles, 1), Some(3));
+        assert_eq!(heading_level_for_istd(&styles, 2), Some(5));
+        // Not a heading: user-defined (sti 0x0FFE) with a non-heading name.
+        assert_eq!(heading_level_for_istd(&styles, 3), None);
+    }
+
+    /// `xstzName` may carry aliases as "primary,alias" (§2.9.258); the level is
+    /// carried by the primary name, so a comma-suffixed name must still resolve.
+    #[test]
+    fn heading_level_uses_primary_name_before_aliases() {
+        let styles = vec![
+            StyleDef::default(),
+            StyleDef {
+                sti: 0x0FFE,
+                name: "Heading 4,Title 4".into(),
+            },
+        ];
+        assert_eq!(heading_level_for_istd(&styles, 1), Some(4));
+    }
+
+    /// Pin the name parser's edges directly, so the allocation-free rewrite
+    /// cannot change what resolves. `heading_level_from_name` is the fallback
+    /// for every style that is not a built-in `sti` 1–9 heading.
+    #[test]
+    fn heading_level_from_name_resolves_only_primary_heading_names() {
+        assert_eq!(heading_level_from_name("Heading 3"), Some(3));
+        assert_eq!(heading_level_from_name("heading 3"), Some(3), "case-insensitive");
+        assert_eq!(heading_level_from_name("HEADING 3"), Some(3));
+        assert_eq!(heading_level_from_name("  Heading 3  "), Some(3), "trims");
+        assert_eq!(
+            heading_level_from_name("Heading 3,Heading 3 Char"),
+            Some(3),
+            "only the primary name carries the level"
+        );
+        assert_eq!(heading_level_from_name(""), None, "empty name is not a heading");
+        assert_eq!(heading_level_from_name("   "), None);
+        assert_eq!(heading_level_from_name("Not A Heading"), None);
+        assert_eq!(heading_level_from_name("Heading"), None, "no level");
+        assert_eq!(heading_level_from_name("Heading 0"), None, "0 is out of range");
+        assert_eq!(heading_level_from_name("Heading 10"), None, "10 is above MAX_OUTLINE_LEVEL");
+        assert_eq!(heading_level_from_name("Headin 3"), None, "prefix must match fully");
+    }
+
+    /// The name parser runs for every paragraph whose style is not a built-in
+    /// heading, so it must not allocate per call. Asserted by construction
+    /// (no `String` is built on any path) rather than by an allocator counter.
+    #[test]
+    fn heading_level_for_istd_does_not_resolve_unstyled_paragraphs() {
+        let styles = vec![
+            StyleDef::default(),
+            StyleDef {
+                sti: 0x0FFE,
+                name: "Body Text".into(),
+            },
+        ];
+        assert_eq!(heading_level_for_istd(&styles, 0), None);
+        assert_eq!(heading_level_for_istd(&styles, 1), None);
+        assert_eq!(heading_level_for_istd(&styles, 99), None, "out of range istd");
+    }
+
+    #[test]
+    fn truncated_style_sheet_is_empty() {
+        assert!(parse_stsh(&[0u8; 4]).is_empty());
+        assert!(parse_stsh(&[18, 0, 0, 0]).is_empty());
+    }
+
+    /// Build a `Fib` whose only non-zero fields are `fc_stshf` / `lcb_stshf`,
+    /// pointing at a style sheet in the Table stream.
+    fn fib_with_stsh(start: u32, len: u32) -> Fib {
+        Fib {
+            version: 0,
+            use_table1: false,
+            clx_offset: 0,
+            clx_size: 0,
+            text_len: 0,
+            footnote_len: 0,
+            header_len: 0,
+            comment_len: 0,
+            endnote_len: 0,
+            textbox_len: 0,
+            header_textbox_len: 0,
+            fc_plcf_bte_papx: 0,
+            lcb_plcf_bte_papx: 0,
+            fc_plcf_lst: 0,
+            lcb_plcf_lst: 0,
+            fc_stshf: start,
+            lcb_stshf: len,
+        }
+    }
+
+    /// `parse_style_sheet` is the FIB-aware wrapper that `document.rs` calls: it
+    /// must slice the STSH out of the Table stream at `fc_stshf` (bounds-checked)
+    /// and hand the bytes to `parse_stsh`. This exercises the wrapper end-to-end
+    /// with real STSH bytes placed at a non-zero offset — the path the POI corpus
+    /// never reaches (every file reports `fc_stshf == 0`).
+    #[test]
+    fn parse_style_sheet_reads_stsh_at_fib_offset() {
+        let stsh = synthetic_stsh();
+        let start = 64usize;
+        let mut table_stream = vec![0u8; start + stsh.len()];
+        table_stream[start..start + stsh.len()].copy_from_slice(&stsh);
+        let fib = fib_with_stsh(start as u32, stsh.len() as u32);
+        let styles = parse_style_sheet(&table_stream, &fib);
+        assert_eq!(styles.len(), 16);
+        assert_eq!(styles[0].sti, 0);
+        assert_eq!(styles[0].name, "Normal");
+        assert_eq!(styles[3].sti, 3);
+        assert_eq!(styles[3].name, "Heading 3");
+        assert_eq!(styles[15].sti, 0x0FFE);
+        assert_eq!(styles[15].name, "heading 7");
+    }
+
+    /// `fcStshf` is an *offset* into the Table stream, and the style sheet is
+    /// normally the first thing written there, so `0` is a **valid** offset, not
+    /// a marker for "absent". [MS-DOC] `FibRgFcLcb97` puts the requirement on
+    /// the length: `lcbStshf` "MUST be a nonzero value" (and `STSH` adds "Each
+    /// FIB MUST contain a stylesheet"). Guarding on the offset therefore
+    /// discards the style sheet of essentially every real document.
+    ///
+    /// This is the case a real `.doc` hits: surveyed over 160 POI corpus files,
+    /// 152 report `lcbStshf != 0` and 147 of those report `fcStshf == 0`.
+    #[test]
+    fn parse_style_sheet_at_offset_zero_is_parsed() {
+        let stsh = synthetic_stsh();
+        // STSH at Table-stream offset 0 — where Word normally writes it.
+        let mut table_stream = stsh.clone();
+        table_stream.resize(stsh.len() + 64, 0);
+        let fib = fib_with_stsh(0, stsh.len() as u32);
+        let styles = parse_style_sheet(&table_stream, &fib);
+        assert_eq!(styles.len(), 16, "an offset of 0 must not be read as 'no style sheet'");
+        assert_eq!(styles[3].name, "Heading 3");
+    }
+
+    #[test]
+    fn parse_style_sheet_absent_is_empty() {
+        let table_stream = vec![0u8; 64];
+        assert!(parse_style_sheet(&table_stream, &fib_with_stsh(0, 0)).is_empty());
+    }
+
+    /// Malformed `fc_stshf` / `lcb_stshf` near `u32::MAX` must not overflow the
+    /// pointer arithmetic: on a 32-bit target `start + len` wraps, and a wrapped
+    /// slice would read arbitrary memory. AGENTS.md rule 6 — no input may panic
+    /// or overflow.
+    ///
+    /// This pins the *contract* (never panics, yields no styles) rather than the
+    /// `saturating_add` itself: on a 64-bit host the sum cannot wrap, so no
+    /// assertion here can tell `saturating_add` from `wrapping_add`.
+    #[test]
+    fn parse_style_sheet_extreme_fib_values_do_not_panic() {
+        let table_stream = vec![0u8; 64];
+        for (start, len) in [(u32::MAX, 100u32), (60u32, u32::MAX), (u32::MAX, u32::MAX)] {
+            assert!(
+                parse_style_sheet(&table_stream, &fib_with_stsh(start, len)).is_empty(),
+                "fc_stshf={start:#x} lcb_stshf={len:#x} must yield no styles"
+            );
+        }
+    }
+
+    /// A style sheet that advertises far more styles than it carries must still
+    /// terminate and return what is actually there — the entry loop and the
+    /// allocation cap are what stop a lying `cstd` from running away.
+    #[test]
+    fn parse_stsh_huge_cstd_terminates_without_inventing_styles() {
+        let mut d = 18u16.to_le_bytes().to_vec(); // cbStshi
+        d.extend_from_slice(&0xFFFFu16.to_le_bytes()); // cstd — lies
+        d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile
+        d.extend_from_slice(&[0u8; 14]);
+        d.extend_from_slice(&lpstd(3, "Heading 3"));
+        let styles = parse_stsh(&d);
+        assert_eq!(styles.len(), 1, "only the one entry actually present");
+        assert_eq!(styles[0].name, "Heading 3");
+    }
+
+    #[test]
+    fn parse_style_sheet_out_of_bounds_is_empty() {
+        let stsh = synthetic_stsh();
+        // Point `fc_stshf` past the end of the table stream.
+        assert!(parse_style_sheet(&stsh, &fib_with_stsh(1000, stsh.len() as u32)).is_empty());
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -644,6 +644,16 @@ pub enum ShapeGeom {
     Rect,
 }
 
+/// The deepest heading level the IR can express: `Heading::level` is 1–
+/// `MAX_HEADING_DEPTH`, a markdown-style depth. Format readers whose native
+/// heading range is deeper (MS-DOC outline levels run to 9) clamp to this when
+/// they build the IR, so every consumer can rely on the bound.
+///
+/// This is the **only** definition of that range: [`Heading::clamped_level`]
+/// and the format emitters all clamp through it, so changing the depth is a
+/// one-line change and no consumer can drift from it.
+pub const MAX_HEADING_DEPTH: u8 = 6;
+
 /// A heading element with a nesting level.
 #[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Heading {
@@ -675,7 +685,7 @@ impl Heading {
     /// documented 1–6 range. This is the single definition of that range;
     /// every renderer and writer calls it.
     pub fn clamped_level(&self) -> u8 {
-        self.level.clamp(1, 6)
+        self.level.clamp(1, MAX_HEADING_DEPTH)
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -90,6 +90,7 @@ pub fn row_grpprl(centers: &[i16], rgfs: &[u16]) -> Vec<u8> {
 }
 
 /// Build a complete synthetic `.doc` from the given paragraphs.
+#[allow(dead_code)]
 pub fn build_doc(paras: &[Para]) -> Vec<u8> {
     build_doc_full(paras, &Subdocs::default(), FibTweaks::default())
 }
@@ -127,6 +128,28 @@ pub struct FibTweaks {
 /// Build a synthetic `.doc`, optionally with subdocuments and FIB tweaks.
 #[allow(dead_code)]
 pub fn build_doc_full(paras: &[Para], subdocs: &Subdocs, tweaks: FibTweaks) -> Vec<u8> {
+    build_inner(paras, subdocs, tweaks, &[], &[])
+}
+
+/// Build a synthetic `.doc` whose paragraphs carry the given PAPX `istd` values
+/// and whose Table stream ends with `stsh` (an STSH style sheet).
+///
+/// Separate from [`build_doc_full`] so the existing tests keep building
+/// style-free documents, and so an integration test can exercise the
+/// style-sheet path through the public API alone — which is what the
+/// revert-check gate needs, since it reverts everything under `src/`.
+#[allow(dead_code)]
+pub fn build_doc_with_styles(paras: &[Para], istds: &[u16], stsh: &[u8]) -> Vec<u8> {
+    build_inner(paras, &Subdocs::default(), FibTweaks::default(), istds, stsh)
+}
+
+fn build_inner(
+    paras: &[Para],
+    subdocs: &Subdocs,
+    tweaks: FibTweaks,
+    istds: &[u16],
+    stsh: &[u8],
+) -> Vec<u8> {
     let n = paras.len();
 
     // Build the main text (UTF-16LE) and the CP range of each paragraph.
@@ -173,11 +196,17 @@ pub fn build_doc_full(paras: &[Para], subdocs: &Subdocs, tweaks: FibTweaks) -> V
     table.extend_from_slice(&build_plcf_bte_papx(n, &cp_starts, text_len));
     let lcb_plcf = (table.len() as u32) - fc_plcf;
 
+    // An optional style sheet appended after the PAPX index; `fcStshf` is an
+    // offset into the Table stream, and 0 is only "absent" when `lcbStshf` is.
+    let fc_stshf = table.len() as u32;
+    let lcb_stshf = stsh.len() as u32;
+    table.extend_from_slice(stsh);
+
     // ── WordDocument stream: FIB + N FKP pages + text. ──
     let wd_len = text_offset as usize + text_bytes.len();
     let wd_sectors = wd_len.div_ceil(512);
     let mut word_doc = vec![0u8; wd_sectors * 512];
-    write_fib(&mut word_doc, text_len, fc_plcf, lcb_plcf);
+    write_fib(&mut word_doc, text_len, fc_plcf, lcb_plcf, fc_stshf, lcb_stshf);
     for (i, &ccp) in ccps.iter().enumerate() {
         let off = 0x50 + i * 4;
         word_doc[off..off + 4].copy_from_slice(&ccp.to_le_bytes());
@@ -200,7 +229,8 @@ pub fn build_doc_full(paras: &[Para], subdocs: &Subdocs, tweaks: FibTweaks) -> V
         };
         let fc0 = text_offset + cp0 * 2;
         let fc1 = text_offset + cp1 * 2;
-        let page = build_fkp_page(fc0, fc1, &p.grpprl);
+        let istd = istds.get(i).copied().unwrap_or(0);
+        let page = build_fkp_page(fc0, fc1, &p.grpprl, istd);
         let off = (i + 1) * 512;
         word_doc[off..off + 512].copy_from_slice(&page);
     }
@@ -208,6 +238,43 @@ pub fn build_doc_full(paras: &[Para], subdocs: &Subdocs, tweaks: FibTweaks) -> V
         .copy_from_slice(&text_bytes);
 
     build_cfb(&word_doc, &table)
+}
+
+/// One `LPStd` for a style sheet: `cbStd(u16)` + `STD`.
+///
+/// `STD` = `stdf` (10 bytes of `StdfBase`, whose low 12 bits are `sti`) plus
+/// `xstzName` (`cch(u16)` + `cch` UTF-16 code units + a 2-byte terminator).
+fn lpstd(sti: u16, name: &str) -> Vec<u8> {
+    let mut std = vec![0u8; 10];
+    std[0..2].copy_from_slice(&sti.to_le_bytes());
+    let units: Vec<u16> = name.encode_utf16().collect();
+    std.extend_from_slice(&(units.len() as u16).to_le_bytes());
+    for u in &units {
+        std.extend_from_slice(&u.to_le_bytes());
+    }
+    std.extend_from_slice(&0u16.to_le_bytes());
+    let mut out = (std.len() as u16).to_le_bytes().to_vec();
+    out.extend_from_slice(&std);
+    out
+}
+
+/// A spec-conformant STSH ([MS-DOC] §2.7.1 / §2.9.274) whose `istd` 1-9 are the
+/// built-in `Heading 1`-`Heading 9` styles and `istd` 0 is `Normal`, so a
+/// paragraph whose PAPX `istd` is 3 resolves to Heading 3.
+#[allow(dead_code)]
+pub fn heading_style_sheet() -> Vec<u8> {
+    let mut d = 18u16.to_le_bytes().to_vec(); // cbStshi
+    d.extend_from_slice(&15u16.to_le_bytes()); // cstd
+    d.extend_from_slice(&0x000Au16.to_le_bytes()); // cbSTDBaseInFile
+    d.extend_from_slice(&[0u8; 14]); // rest of the 18-byte Stshif
+    d.extend_from_slice(&lpstd(0, "Normal"));
+    for lvl in 1..=9u16 {
+        d.extend_from_slice(&lpstd(lvl, &format!("Heading {lvl}")));
+    }
+    for _ in 0..5 {
+        d.extend_from_slice(&[0u8; 2]); // empty LPStd (cbStd = 0)
+    }
+    d
 }
 
 /// Open a synthetic `.doc` byte buffer through the public API.
@@ -220,12 +287,21 @@ pub fn open_doc(bytes: &[u8]) -> Document {
 // ── CFB / DOC byte construction ──
 
 /// Write the FIB into the first 512 bytes of `word_doc`.
-fn write_fib(word_doc: &mut [u8], text_len: u32, fc_plcf: u32, lcb_plcf: u32) {
+fn write_fib(
+    word_doc: &mut [u8],
+    text_len: u32,
+    fc_plcf: u32,
+    lcb_plcf: u32,
+    fc_stshf: u32,
+    lcb_stshf: u32,
+) {
     word_doc[0..2].copy_from_slice(&0xA5ECu16.to_le_bytes()); // wIdent = Word 97+
     word_doc[2..4].copy_from_slice(&0x00C1u16.to_le_bytes()); // nFib
     // flags at 0x0A: bit 9 (fWhichTblStm) clear → use 0Table.
     word_doc[0x0A..0x0C].copy_from_slice(&0u16.to_le_bytes());
     word_doc[0x4C..0x50].copy_from_slice(&text_len.to_le_bytes()); // ccpText
+    word_doc[0x00A2..0x00A6].copy_from_slice(&fc_stshf.to_le_bytes()); // fcStshf
+    word_doc[0x00A6..0x00AA].copy_from_slice(&lcb_stshf.to_le_bytes()); // lcbStshf
     word_doc[0x01A2..0x01A6].copy_from_slice(&0u32.to_le_bytes()); // fcClx = 0
     word_doc[0x01A6..0x01AA].copy_from_slice(&21u32.to_le_bytes()); // lcbClx = CLX size
     word_doc[0x0102..0x0106].copy_from_slice(&fc_plcf.to_le_bytes());
@@ -261,7 +337,7 @@ fn build_plcf_bte_papx(n: usize, cp_starts: &[u32], text_len: u32) -> Vec<u8> {
 }
 
 /// Build one 512-byte PAPX FKP page holding a single paragraph.
-fn build_fkp_page(fc0: u32, fc1: u32, grpprl: &[u8]) -> [u8; 512] {
+fn build_fkp_page(fc0: u32, fc1: u32, grpprl: &[u8], istd: u16) -> [u8; 512] {
     let mut page = [0u8; 512];
     page[0..4].copy_from_slice(&fc0.to_le_bytes());
     page[4..8].copy_from_slice(&fc1.to_le_bytes());
@@ -274,6 +350,7 @@ fn build_fkp_page(fc0: u32, fc1: u32, grpprl: &[u8]) -> [u8; 512] {
     }
     let cw = ((3 + g.len()) / 2) as u8;
     let mut papx = vec![cw, 0, 0];
+    papx[1..3].copy_from_slice(&istd.to_le_bytes());
     papx.extend_from_slice(&g);
 
     // PAPX stored at word offset 11 (byte 22); BX byte 0 carries the word off.

--- a/tests/test_doc_style_heading_integration.rs
+++ b/tests/test_doc_style_heading_integration.rs
@@ -1,0 +1,100 @@
+//! Style-sheet heading levels, reached through the public API.
+//!
+//! These live in `tests/` rather than in a `#[cfg(test)]` module under `src/`
+//! on purpose. `scripts/revert-check.sh` reverts every changed file under
+//! `src/` before running the suite, so a unit test that sits in the same file
+//! as the code it covers is reverted along with it — the suite then passes with
+//! the production change removed, and the gate correctly reports that nothing
+//! was proven. A test out here survives the revert, so reverting the
+//! style-sheet parser must make *this* fail.
+//!
+//! The document is built in code (AGENTS.md rule #4 — no committed third-party
+//! fixture).
+
+mod common;
+
+use common::{Para, build_doc_with_styles, heading_style_sheet, open_doc, prose_grpprl};
+use office_oxide::ir::Element;
+
+/// Pull the `(level, text)` of every `Heading` out of a parsed document.
+fn headings(doc: &office_oxide::Document) -> Vec<(u8, String)> {
+    let ir = doc.to_ir();
+    let mut out = Vec::new();
+    for section in &ir.sections {
+        for element in &section.elements {
+            if let Element::Heading(h) = element {
+                let text: String = h
+                    .content
+                    .iter()
+                    .filter_map(|c| match c {
+                        office_oxide::ir::InlineContent::Text(t) => Some(t.text.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                out.push((h.level, text));
+            }
+        }
+    }
+    out
+}
+
+/// A paragraph whose PAPX `istd` points at the built-in `Heading 3` style must
+/// come out as a level-3 heading.
+///
+/// Level 3 cannot come from the line-shape guess, which caps at 2, and
+/// "Subsection Three" is neither ALL-CAPS nor a short opening line, so under a
+/// build with no style-sheet parsing this paragraph is ordinary prose. That
+/// asymmetry is what makes this test evidence rather than a tautology.
+#[test]
+fn heading_style_from_the_style_sheet_sets_the_real_level() {
+    let paras = [
+        Para {
+            text: "Introduction.",
+            terminator: '\r',
+            grpprl: prose_grpprl(),
+        },
+        Para {
+            text: "Subsection Three",
+            terminator: '\r',
+            grpprl: prose_grpprl(),
+        },
+    ];
+    // istd 0 = Normal, istd 3 = Heading 3 per the style sheet below.
+    let bytes = build_doc_with_styles(&paras, &[0, 3], &heading_style_sheet());
+    let doc = open_doc(&bytes);
+
+    let found = headings(&doc);
+    assert_eq!(found.len(), 1, "only the styled paragraph is a heading; got {found:?}");
+    assert_eq!(found[0].1, "Subsection Three");
+    assert_eq!(
+        found[0].0, 3,
+        "a `Heading 3` style must produce level 3, not the heuristic's 1 or 2"
+    );
+}
+
+/// The same document without a style sheet must not invent the level: nothing
+/// marks the paragraph as a heading, so it stays prose. This is the contrast
+/// that keeps the test above honest.
+#[test]
+fn without_a_style_sheet_the_same_paragraph_is_not_a_heading() {
+    let paras = [
+        Para {
+            text: "Introduction.",
+            terminator: '\r',
+            grpprl: prose_grpprl(),
+        },
+        Para {
+            text: "Subsection Three",
+            terminator: '\r',
+            grpprl: prose_grpprl(),
+        },
+    ];
+    let bytes = build_doc_with_styles(&paras, &[0, 3], &[]);
+    let doc = open_doc(&bytes);
+
+    assert!(
+        headings(&doc).is_empty(),
+        "no style sheet means no style-derived level; got {:?}",
+        headings(&doc)
+    );
+}


### PR DESCRIPTION
## Linked issue

Closes #132

## What and why

Legacy binary `.doc` headings were classified purely by a line heuristic
(short ALL-CAPS lines → heading; first short line → title; everything else →
body). That ignores the real outline level stored in the document, so every
*styled* heading collapsed to level 1 or 2 regardless of its actual level, and
non-ALL-CAPS styled headings were missed entirely.

This PR (Tier 1 of the plan in the linked issue) derives the real heading level
from the document itself:

- `sprmPOutLvl` (**`0x2640`**, [MS-DOC] §2.6.2) is authoritative when present:
  its **1-byte** operand is **zero-based**, so `0x00`–`0x08` are Heading 1–9 and
  `0x09` means body text. Direct formatting beats the style in Word, so when the
  SPRM is present with a valid operand it settles the level — including the
  body-text marker `0x09`, which *suppresses* a heading style instead of falling
  through to it. An operand above `0x09` is not a valid outline level and is
  ignored (the paragraph then resolves from its style). This is the review
  correction: an earlier revision used `0x6412` (`sprmPDyaLine`, line spacing)
  and an inverted value space — reading line spacing as a heading level turned
  every "Exactly 12.5pt" paragraph into a heading.
- Otherwise the paragraph's style is resolved: the PAPX header `istd`,
  overridden by `sprmPIstd` (**`0x4600`**, 2-byte operand) when present in the
  grpprl, is looked up in the STSH style sheet ([MS-DOC] §2.7.1). Built-in
  styles carry `sti` 1–9 (resolved directly, which also keeps working when Word
  localises the names — "Überschrift 3", "Titre 3"); user-defined ones resolve
  via a `Heading N` name (case-insensitive, primary name before aliases).
- The 1–9 outline level is clamped to `Heading::level`'s 1–6 markdown depth,
  matching the DOCX path's `(outline_level + 1).min(6)`.

Paragraphs that resolve to no heading keep the previous heuristic, so documents
without usable style data are unaffected. A style sheet that is absent
(`fcStshf == 0`), out of bounds, truncated or malformed yields an empty style
list and degrades to the heuristic rather than failing the parse; every parse
step is bounds-checked (no panic).

The style sheet itself is decoded per the MS-DOC [STSH] layout: `cbStshi` +
`Stshif` (exactly 18 bytes, no names) followed directly by `rglpstd`, with each
style's name read from `STD.xstzName` (§2.9.258/§2.9.354) rather than from any
shared name table. An earlier revision of this PR inserted a style-name `STTB`
between `Stshif` and `rglpstd`; that was caught in self-review and corrected —
it would have left the style list empty on real files and silently disabled this
path. Fixtures are now built from the spec (15 fixed-index entries: Normal +
Heading 1–9, istd 13–14 empty) so they cannot merely re-encode the decoder, and
a guard asserts the old layout yields no names instead of plausible ones.

[STSH]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/c8ee0f39-02c3-4caa-b27a-6a97600130fe

## Type of change

- [ ] Bug fix
- [x] New feature (has an accepted issue: #132)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). Rather than eyeballing it, I reverted **each production
      hunk this PR adds, one at a time**, and required a test to go red:

      | reverted hunk | tests that went red |
      |---|---|
      | style-sheet guard (`lcb_stshf`) | 1 |
      | `cbSTDBaseInFile` validation | 1 |
      | odd-size `LPStd` padding skip | 1 |
      | primary-name split for aliases | 1 |
      | `sprmPIstd` (0x4600) arm | 3 |
      | `sprmPOutLvl` (0x2640) arm | 5 |
      | explicit body-text marker | 1 |
      | `resolve_outline_level` explicit branch | 5 |
      | the single `outline_level` write in `build_paragraphs` | 5 |
      | `heading_level_for_istd` `sti` branch | 1 |
      | `parse_stsh` entry decode | 8 |
      | **reintroduced the original 0x6412 bug arm** | 1 |

      12/12 hunks covered; 25 distinct tests went red across the matrix.

      Two tests were **removed** rather than kept as decoration: one asserted
      `.all()` over a vector that is empty (true under any implementation), and
      one used a byte value the buggy decoder also rejected, so it could not
      tell the two apart. Both had been counted as coverage before; neither was.

      What the tests pin:
      - **Style sheet / `istd`** — `synthetic_doc_styled_heading_uses_style_sheet_level`
        builds a synthetic `.doc` whose style sheet resolves `istd` 3 to
        `Heading 3`; level 3 can only come from there (the heuristic tops out at 2).
        `heading_level_resolves_localized_builtin_style_via_sti` covers the
        `sti` path on its own — real Word localises built-in names ("Überschrift 3",
        "Titre 3"), which the name-based path cannot match.
      - **Outline SPRM** — `sprm_p_out_lvl_zero_is_heading_one`,
        `..._eight_is_heading_nine`, `..._nine_is_body_text`,
        `..._above_nine_is_not_an_outline_level` pin the **zero-based** operand
        (0x00–0x08 = Heading 1–9, 0x09 = body text). `sprm_p_dya_line_is_not_read_as_an_outline_level`
        guards the opcode confusion this PR originally shipped — 0x6412 is
        `sprmPDyaLine` (line spacing), not an outline level. The three states
        are one value (`OutlineLevel::{Heading,BodyText}` inside an `Option`),
        not a level plus a bool: two fields that must agree is a state that one
        caller will eventually set halfway.
      - **The gate** — `style_derived_heading_switches_off_the_line_shape_guess`
        pins that a level resolved from a *style*, not only one from
        `sprmPOutLvl`, turns the line-shape guess off for the whole document.
        Its body line is short, ALL-CAPS and has no trailing '.', i.e. exactly
        the shape the guess would otherwise promote — so the assertion is about
        the gate rather than about the line shape.
      - **Precedence** — `build_paragraphs_sprm_out_lvl_overrides_style` (SPRM beats
        the style), `build_paragraphs_sprm_out_lvl_body_marker_suppresses_styled_heading`
        (an explicit body-text marker suppresses a heading style), and
        `build_paragraphs_sprm_istd_override_can_remove_a_heading` (the style
        override must remove a heading as well as add one).
      - **Boundary** — `build_paragraphs_sprm_out_lvl_accepts_deepest_level` pins
        that the SPRM does **not** pre-clamp; `ir_deep_outline_level_clamps_to_ir_max_depth`
        pins the clamp to `MAX_HEADING_DEPTH` at the IR boundary.
      - **Non-interference** — a styled heading inside a table, on a row
        terminator, or on a list item must stay a cell / row end / list item.
        Each of those three also asserts the **contrast** (the same paragraph as
        ordinary prose *does* emit a Heading, using text the heuristic rejects),
        because without it they passed with the new branch deleted.
- [x] Test named by defect **class** (style-sheet / outline-SPRM heading level),
      no issue/PR number or contributor name in code/fixtures.
- [x] `cargo test --all-targets` passes (536 lib tests, 0 failures); affected
      feature tier: legacy `.doc` parsing + IR. `cargo check --features
      python,parallel,mmap` is clean.
- [x] `cargo fmt --check` and `cargo clippy --all-targets --workspace --
      -D warnings` are clean.

### Coverage of the remaining antiword disagreements

The 12 POI disagreements with antiword are *outside* the code this PR changes —
which the revert matrix above already pins. To prove that rather than assert it,
each was traced with per-paragraph instrumentation (`istd`, SPRM override,
explicit flag, resolved level):

| bucket | meaning | count | files |
|---|---|---|---|
| 1 — our parsing defect | a real level we *should* have resolved but didn't | **0** | — |
| 2 — heuristic fallback | paragraph has no resolvable `istd` → falls back to the heuristic (its level 2) | 2 | `o_kurs`, `ob_is` |
| 3 — antiword relative nesting | `level=-`, the gap is antiword's *relative* DocBook nesting vs our guess | 10 | `52420`, `60279` (×5), `Bug33519` (×2), `Bug52032_1`, `parentinvguid` (×2) |

**All 12 have `level=-`** — our new code resolved *no* heading level wrong, so
there is no test this PR could add that would change the result. Bucket 1 = 0
means the revert matrix is complete: every defect this PR introduces or fixes is
covered. The disagreements live entirely in the line-shape heuristic the
maintainer has said he will retire (issue #132, "Known follow-on").

## Regression on real Office files

**Files in my corpus that carry a style sheet: 371 of 387** (357 of those with a
spec-valid STSH). This is the number the earlier revision could not give: it
reported "byte-identical output", which for an additive classification change is
indistinguishable from "the code never ran" — and the code had in fact been
switched off by its own `fc_stshf == 0` guard.

### Corpora (my own copies, kept local — not committed, per CONTRIBUTING #4)

| Source | Files | Licence | How to fetch |
|---|---|---|---|
| Apache POI `test-data/document` | 160 | Apache-2.0 | `git clone --depth 1 --filter=blob:none --sparse https://github.com/apache/poi.git && git sparse-checkout set test-data/document` |
| LibreOffice core `sw/qa/extras/ww8{export,import}/data` | 177 | MPL-2.0 | `gh api repos/LibreOffice/core/contents/<dir> --jq '.[] | select(.name | test("\\.doc$";"i")) | .download_url'` |
| Apache Tika test documents | 50 | Apache-2.0 | `gh api "repos/apache/tika/git/trees/main?recursive=1" --jq '.tree[].path | select(test("\\.doc$";"i"))'` |

Three producers, not three copies of one: they disagree about which style-sheet
form dominates (POI 56 × `cbSTDBaseInFile=0x000A` / 84 × `0x0012`;
LibreOffice 33 / 141), so both branches of the STSH decoder see real data.

### Reach of the new code path (measured, not asserted)

The style-sheet counts come from a standalone CFB/FIB reader, so they describe
the *files* rather than this parser's success at opening them:

| | POI | LibreOffice | Tika | Total |
|---|---|---|---|---|
| files | 160 | 177 | 50 | **387** |
| `lcbStshf != 0` (style sheet) | 152 | 175 | 44 | **371** |
| spec-valid STSH | 140 | 174 | 43 | **357** |
| ...with `fcStshf == 0` | 147 | 175 | 43 | **365** |

`fcStshf == 0` is the *normal* case, not an absent style sheet — which is why a
guard on the offset switched this path off on essentially every real file.

### Extraction over the corpus (baseline: v0.1.10)

Measured against **v0.1.10**, the commit this branch is rebased onto. Of 387
files, **351 open** on both builds (36 errors each — **no new errors**,
**0 panics**):

| | baseline `v0.1.10` | this branch | delta |
|---|---|---|---|
| docs with headings | 196 | **201** | **+5** |
| headings | 514 | **678** | **+164** |
| errors | 36 | 36 | **0** |

**What the style-sheet path itself is responsible for.** The A/B — the same
build with `parse_style_sheet` returning empty, which reproduces v0.1.10 to
within one heading:

| | styles off | styles on |
|---|---|---|
| headings (deduped by file+text) | 391 | **554** |

- **+163** headings whose level exists only in a style, across **35 files** —
  these are what this PR is for
- **16** re-levelled to a real level
- **1** no longer produced: `tdf81705_outlineLevel.doc`, where a paragraph
  explicitly marked body text is no longer guessed back into being a heading

No document loses a heading. `parentinvguid.doc` goes **35 → 37**.

### The gate: keyed on `sprmPOutLvl`, and why

`has_structured_headings` means "some paragraph **states its own** level via
`sprmPOutLvl`", not "some paragraph's level resolved". The difference is the
walk, not the totals: `walk_paragraphs` routes list members (`ilfo`), table
cells, row marks and empty paragraphs *before* `emit_heading`, so under an
outcome-based gate a paragraph can trip it and then emit nothing — one
`Heading 1`-styled numbered paragraph, a styled table cell or an empty styled
paragraph turns the guess off for the whole document, which then has no headings
and no `metadata.title`. Numbered headings are the normal shape in real Word
documents, so style-resolved levels make that common in a way the SPRM path
never did.

The source is carried in the value rather than in a parallel bool:

```rust
OutlineLevel::Heading { level: u8, source: LevelSource }  // LevelSource::{Sprm, Style}
```

Both halves are pinned by their own test — `sprm_derived_heading_switches_off_the_line_shape_guess`
and `style_derived_heading_does_not_switch_off_the_line_shape_guess` — since
without them `LevelSource` would be untested payload. Confirmed by mutation:
matching `Style`, ignoring the source, and mislabelling a style-resolved level
as `Sprm` each make a test fail.

Retiring the line-shape guess entirely is tracked separately (#224); the guesses
it suppresses are genuinely mixed ("INTRODUCTION" alongside "SW8 5NQ"), and
tying the new path to that decision would be a side effect, not a choice.

### Independent cross-check: antiword

`antiword -x db` (DocBook nesting → level) over the same files, recomputed
against this branch's current output: of the headings both extractions find
(**82**), **74 agree on level (90%)**. `antiword` keys on `istd` ∈ 1..=9 and its
DocBook nesting is *relative*, so its absolute levels are not authoritative —
this is a sanity check, not an oracle.

The disagreements were traced with per-paragraph instrumentation (`istd`, SPRM
override, explicit flag, resolved level); the full three-bucket breakdown is in
the **Tests** section, "Coverage of the remaining antiword disagreements",
above. The headline: **bucket 1 = 0** — the new code resolved *no* heading level
wrong; every one is a paragraph with no styled heading that fell back to the
line-shape heuristic, which guesses wrong. That is exactly the code the
maintainer has said he will retire (issue #132, "Known follow-on"), so **none of
them is in scope for this PR**.

`antiword` does not, however, key on `istd` alone, and the file that decides the
value space does not need it to — see #132, "Real document".

### Note on `ir.rs`'s `Paragraph.outline_level`

This PR does not write that field and does not depend on its documented model
(0 = body text). The level it resolves lives in `PapProps::outline_level`, which
is **zero-based** — [MS-DOC]'s own value space, `0` = Heading 1 … `8` = Heading 9,
`9` = body text — and is turned into the IR's 1–6 depth by `emit_heading`. Using
the zero-based representation is deliberate: it is the same one v0.1.10's
`sprmPOutLvl` decoding already uses, so there is one field and one offset
convention rather than two fields kept in step by hand.

### Synthetic exhibits (issue #132)

`headings.doc` (generated in code by `gen_doc_headings.rs`) still exercises the
pipeline end to end, and a **real** document — `apache/poi`
`test-data/document/Bug49820.doc` — is now named there with a before/after and
an antiword comparison.

## AI assistance disclosure

- [x] AI assistance: **assisted** — tool: AI coding agent, extent: drafted code
      and tests with the human author reviewing, correcting, and owning every
      line; the human author understands and can explain every line.
- [x] I understand and can explain every line; this description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits.
- [x] Non-trivial contribution: I will sign the CLA when the bot asks (see CLA.md).
- [x] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
