### PR TITLE
docs(contributing): fix stale task pointers, add "Where Help Is Wanted"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ more than the time it takes to review it. We are not anti-AI; we are anti-slop.
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
 - [Project Structure](#project-structure)
+- [Where Help Is Wanted](#where-help-is-wanted)
 - [Development Workflow](#development-workflow)
 - [Coding Standards](#coding-standards)
 - [Testing](#testing)
@@ -144,13 +145,40 @@ office_oxide/
 └── docs/                  # Architecture, per-language getting-started guides
 ```
 
+## Where Help Is Wanted
+
+Individual issues come and go; these areas are durably open. Pick one, then open an
+issue describing what you intend to do **before** writing non-trivial code — see
+[the rules that matter most](#the-rules-that-matter-most).
+
+| Area | What it looks like | Extra bar for this area |
+| --- | --- | --- |
+| **Legacy binary formats** (`src/doc/`, `src/xls/`, `src/ppt/`) | Structures the parsers don't read yet — outline levels, fields, embedded objects, legacy code-page decode. Every claim traced to the MS-DOC / MS-XLS / MS-PPT spec section it comes from. | A **real** file that exercises the new path, not only a synthetic one. A parser change whose new branches are reached by no real document is not yet proven. |
+| **IR and renderers** (`src/ir.rs`, `src/ir_render.rs`) | Fidelity gaps in `plain_text` / `markdown` / `html` — spacing, nesting, list numbering, table shape. | Before/after output for the affected documents, and confirmation the other two renderers didn't shift. |
+| **Binding parity** (`go/`, `js/`, `csharp/`, `src/wasm.rs`) | The Python surface leads and the others lag. Closing one specific gap is a well-scoped task. | An example under `examples/<lang>/` plus a test in that binding's CI job. |
+| **Robustness** | Malformed, truncated or hostile files must return an error — never panic, hang, or allocate unboundedly. | A synthetic malformed input as a test, and a statement that it fails before your fix. |
+| **Docs and examples** (`docs/`, `examples/`) | Getting-started guides, per-language examples, corrections. | Exempt from the accepted-issue rule — just open the PR. |
+
+Smaller entry points are labelled
+[`good first issue`](https://github.com/yfedoseev/office_oxide/labels/good%20first%20issue)
+and [`help wanted`](https://github.com/yfedoseev/office_oxide/labels/help%20wanted).
+They are applied sparingly, so an empty list is normal rather than a sign that
+nothing needs doing — the table above is the better starting point.
+
 ## Development Workflow
 
 ### 1. Pick a Task
 
-- Check [Issues](https://github.com/yfedoseev/office_oxide/issues)
-- Look for issues labeled `help-wanted` or `good-first-issue`
-- Comment on the issue to claim it
+- Browse [open issues](https://github.com/yfedoseev/office_oxide/issues), or pick an
+  area from [Where Help Is Wanted](#where-help-is-wanted).
+- Comment on the issue to claim it, and **wait for a maintainer to accept the
+  approach** before writing non-trivial code. Work that arrives as a finished pull
+  request with no agreed issue may be closed without detailed review, however good
+  it is — agreeing the shape first is what protects your time, not just ours.
+- No issue that fits? Open one. The
+  [Feature Request](https://github.com/yfedoseev/office_oxide/issues/new?template=feature_request.yml)
+  template asks for the problem before the solution; if your work is one step of a
+  larger plan, describe the whole plan there so the scope is agreed once.
 
 ### 2. Create a Branch
 
@@ -208,9 +236,9 @@ make check-all
 Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```bash
-git commit -m "feat: add PDF object parser"
-git commit -m "fix: correct unicode mapping in ToUnicode CMap"
-git commit -m "docs: update API documentation"
+git commit -m "feat(xlsx): expand shared formulas on read"
+git commit -m "fix(doc): correct code-page decode for legacy text runs"
+git commit -m "docs: document the DocumentIR table model"
 ```
 
 Commit types:
@@ -289,19 +317,33 @@ pub fn open(path: &Path) -> Result<Document> {
 
 ### Unit Tests
 
+Build the input **in code**. No third-party or customer document is committed as
+a fixture, so tests construct the bytes they need and parse them from memory:
+
 ```rust
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     #[test]
-    fn test_parse_document() {
-        let doc = Document::open("tests/fixtures/simple.docx").unwrap();
-        let text = doc.plain_text();
-        assert!(text.contains("Hello"));
+    fn heading_style_becomes_a_heading() {
+        let bytes = build_minimal_docx(/* the one construct under test */);
+        let doc = Document::from_reader(Cursor::new(bytes), DocumentFormat::Docx).unwrap();
+        assert!(doc.plain_text().contains("Hello"));
     }
 }
 ```
+
+Name the test after the **defect class** it guards (`heading_style_becomes_a_heading`),
+not after an issue or PR number.
+
+Ready-made builders already exist — reuse them rather than writing another:
+
+- `tests/common/mod.rs` — a synthetic `.doc` writer (`build_doc`, `open_doc`,
+  `prose_grpprl`, `row_grpprl`, `cell_grpprl`) that emits a real CFB/OLE2 container.
+- `tests/docx_integration.rs` — `DocxBuilder`, which assembles a minimal OPC package
+  part by part.
 
 ### Integration Tests
 


### PR DESCRIPTION
## Linked issue

None — docs-only change, exempt under CONTRIBUTING.md rule #1.

## What and why

The "Pick a Task" section was a dead end: it told contributors to look for issues
labelled `help-wanted` and `good-first-issue`, but this repo's labels are
`help wanted` and `good first issue` (spaces), and **no open issue carries either**.
A contributor following the document finds nothing and invents their own scope —
which then collides with rule #1 after the work is already written. #127 is a live
example of that failure mode.

Changes:

- **New "Where Help Is Wanted" section.** Durable areas rather than a list that
  goes stale — legacy binary formats, IR/renderers, binding parity, robustness,
  docs — each with the extra proof bar that area carries. A parser change whose new
  branches are reached by no real document is called out as not yet proven.
- **Fixed the label names**, linked the label pages, and said plainly that an empty
  list is normal. "Pick a Task" now points at the Feature Request template and
  explains that agreeing scope up front protects the contributor's time, not just
  the maintainer's.
- **Replaced the commit-message examples**, which were pdf_oxide leftovers
  (`add PDF object parser`, `ToUnicode CMap`), with office_oxide ones.
- **Replaced the unit-test example.** It loaded `tests/fixtures/simple.docx` — a
  path that does not exist and that contradicts the no-committed-fixtures rule two
  screens above it. It now builds bytes in code via `Document::from_reader`, names
  the test by defect class, and points at the synthetic builders that already exist
  (`tests/common/mod.rs`, `DocxBuilder` in `tests/docx_integration.rs`).

## Type of change

- [ ] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [x] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] N/A — documentation only, no code changes. API names used in the new example
      (`Document::from_reader`, `DocumentFormat::Docx`) and the helper names quoted
      from `tests/common/mod.rs` were checked against the current tree.

## Regression on real Office files

N/A — this PR touches no parsing/extraction/IR code.

## AI assistance disclosure

- [x] AI assistance: **assisted** — tool: Claude Code, extent: located the stale
      pointers and drafted the wording; I reviewed and own the result.

## Checklist

- [x] One logical change.
- [x] Commits follow Conventional Commits.
- [x] Maintainer contribution — CLA/DCO sign-off present.

## Not changed here

CONTRIBUTING.md says issues and PRs opened without filling in their template "are
closed automatically". `.github/workflows/template-compliance.yml` is deliberately
narrower — it only closes a body that is *effectively empty* after stripping
headings and checkboxes. Left as-is: whether to soften the doc or tighten the
workflow is a policy call, not a typo fix.

https://claude.ai/code/session_015MUF5yGEweCjSwhzFt8HMf
